### PR TITLE
Feat: 환자 -> 간병인 찾기, 간병인 -> 환자 찾기 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
+**/generated

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,11 @@ dependencies {
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
     implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4'
 
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'
@@ -43,4 +48,19 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+clean {
+    delete file(generated)
 }

--- a/src/main/java/com/patientpal/backend/caregiver/controller/CaregiverControllerV1.java
+++ b/src/main/java/com/patientpal/backend/caregiver/controller/CaregiverControllerV1.java
@@ -5,10 +5,12 @@ import static org.springframework.http.HttpStatus.OK;
 
 import com.patientpal.backend.caregiver.dto.request.CaregiverProfileCreateRequest;
 import com.patientpal.backend.caregiver.dto.request.CaregiverProfileUpdateRequest;
-import com.patientpal.backend.caregiver.dto.response.CaregiverProfileResponse;
+import com.patientpal.backend.caregiver.dto.response.CaregiverProfileDetailResponse;
 import com.patientpal.backend.caregiver.service.CaregiverService;
 import com.patientpal.backend.image.dto.ImageNameDto;
 import com.patientpal.backend.image.service.PresignedUrlService;
+import com.patientpal.backend.common.querydsl.ProfileSearchCondition;
+import com.patientpal.backend.patient.dto.response.PatientProfileListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,10 +18,19 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "간병인", description = "간병인 프로필 관리 API")
 @RestController
@@ -31,14 +42,14 @@ public class CaregiverControllerV1 {
     private final PresignedUrlService presignedUrlService;
 
     @Operation(summary = "간병인 프로필 생성", description = "간병인 프로필을 새로 생성합니다. 선택적으로 이미지를 업로드할 수 있습니다.")
-    @ApiResponse(responseCode = "201", description = "간병인 프로필 생성 성공", content = @Content(schema = @Schema(implementation = CaregiverProfileResponse.class)))
+    @ApiResponse(responseCode = "201", description = "간병인 프로필 생성 성공", content = @Content(schema = @Schema(implementation = CaregiverProfileDetailResponse.class)))
     @PostMapping
-    public ResponseEntity<CaregiverProfileResponse> createCaregiverProfile(
+    public ResponseEntity<CaregiverProfileDetailResponse> createCaregiverProfile(
             @AuthenticationPrincipal User currentMember,
             @RequestBody @Valid CaregiverProfileCreateRequest caregiverProfileCreateRequest,
             @RequestParam(required = false) String profileImageUrl) {
-        CaregiverProfileResponse caregiverProfileResponse = caregiverService.saveCaregiverProfile(currentMember.getUsername(), caregiverProfileCreateRequest, presignedUrlService.getSavedUrl(profileImageUrl));
-        return ResponseEntity.status(CREATED).body(caregiverProfileResponse);
+        CaregiverProfileDetailResponse caregiverProfileDetailResponse = caregiverService.saveCaregiverProfile(currentMember.getUsername(), caregiverProfileCreateRequest, presignedUrlService.getSavedUrl(profileImageUrl));
+        return ResponseEntity.status(CREATED).body(caregiverProfileDetailResponse);
     }
 
     @Operation(summary = "AWS S3에 저장될 전체 URL 경로 생성", description = "이미지 업로드를 위한 URL을 생성합니다. 생성된 URL로 파일 첨부 후 PUTMAPPING 진행 시 이미지가 저장됩니다.")
@@ -50,9 +61,9 @@ public class CaregiverControllerV1 {
     }
 
     @Operation(summary = "간병인 프로필 조회", description = "현재 로그인된 사용자의 간병인 프로필을 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "간병인 프로필 조회 성공", content = @Content(schema = @Schema(implementation = CaregiverProfileResponse.class)))
+    @ApiResponse(responseCode = "200", description = "간병인 프로필 조회 성공", content = @Content(schema = @Schema(implementation = CaregiverProfileDetailResponse.class)))
     @GetMapping
-    public ResponseEntity<CaregiverProfileResponse> getCaregiverProfile(
+    public ResponseEntity<CaregiverProfileDetailResponse> getCaregiverProfile(
             @AuthenticationPrincipal User currentMember) {
         return ResponseEntity.status(OK).body(caregiverService.getProfile(currentMember.getUsername()));
     }
@@ -102,5 +113,14 @@ public class CaregiverControllerV1 {
             @AuthenticationPrincipal User currentMember) {
         caregiverService.unregisterCaregiverProfileToMatchList(currentMember.getUsername());
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "환자 찾기", description = "지역, 이름, 성별, 나이로 환자를 검색합니다. sort='field',asc/desc로 정렬 가능합니다. ")
+    @ApiResponse(responseCode = "200", description = "조건에 해당하는 환자 찾기 성공")
+    @GetMapping("/search")
+    public ResponseEntity<PatientProfileListResponse> searchPatients(ProfileSearchCondition condition,
+                                                                       @PageableDefault(size = 5) Pageable pageable) {
+        final PatientProfileListResponse searchedProfiles = caregiverService.searchPageOrderBy(condition, pageable);
+        return ResponseEntity.status(OK).body(searchedProfiles);
     }
 }

--- a/src/main/java/com/patientpal/backend/caregiver/domain/Caregiver.java
+++ b/src/main/java/com/patientpal/backend/caregiver/domain/Caregiver.java
@@ -5,12 +5,15 @@ import static jakarta.persistence.FetchType.LAZY;
 import com.patientpal.backend.common.BaseTimeEntity;
 import com.patientpal.backend.matching.domain.Match;
 import com.patientpal.backend.member.domain.Address;
+import com.patientpal.backend.member.domain.Gender;
 import com.patientpal.backend.member.domain.Member;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -19,6 +22,9 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -51,11 +57,16 @@ public class Caregiver extends BaseTimeEntity {
     @Column(unique = true)
     private String residentRegistrationNumber;
 
+    private int age;
+
     @Column(nullable = false, unique = true)
     private String phoneNumber;
 
     @Embedded
     private Address address;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
 
     private float rating;
 
@@ -74,13 +85,15 @@ public class Caregiver extends BaseTimeEntity {
     private String profileImageUrl;
 
     @Builder
-    public Caregiver(Member member, String name, String residentRegistrationNumber, String phoneNumber, Address address,
+    public Caregiver(Member member, String name, String residentRegistrationNumber, String phoneNumber, Address address, Gender gender, int age,
                      float rating, int experienceYears, String specialization, String caregiverSignificant, Boolean isInMatchList, String profileImageUrl) {
         this.member = member;
         this.name = name;
         this.residentRegistrationNumber = residentRegistrationNumber;
         this.phoneNumber = phoneNumber;
         this.address = address;
+        this.gender = gender;
+        this.age = age;
         this.rating = rating;
         this.experienceYears = experienceYears;
         this.specialization = specialization;
@@ -103,5 +116,31 @@ public class Caregiver extends BaseTimeEntity {
 
     public void updateProfileImage(String profileImageUrl) {
         this.profileImageUrl = profileImageUrl;
+    }
+
+    //TODO 나이 예외 처리
+    //EX. 011012-1408293 => 126살로 나옴.
+    public static int getAge(String rrn) {
+        String birthDateString = rrn.substring(0, 6);
+        int century;
+
+        char genderCode = rrn.charAt(7);
+        if (genderCode == '1' || genderCode == '2' || genderCode == '5' || genderCode == '6') {
+            century = 1900;
+        } else if (genderCode == '3' || genderCode == '4' || genderCode == '7' || genderCode == '8') {
+            century = 2000;
+        } else {
+            throw new IllegalArgumentException("Invalid RRN");
+        }
+
+        String birthYear = String.valueOf(century + Integer.parseInt(birthDateString.substring(0, 2)));
+        String birthMonthDay = birthDateString.substring(2);
+        String fullBirthDateString = birthYear + birthMonthDay;
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+        LocalDate birthDate = LocalDate.parse(fullBirthDateString, formatter);
+
+        LocalDate currentDate = LocalDate.now();
+        return Period.between(birthDate, currentDate).getYears();
     }
 }

--- a/src/main/java/com/patientpal/backend/caregiver/dto/request/CaregiverProfileCreateRequest.java
+++ b/src/main/java/com/patientpal/backend/caregiver/dto/request/CaregiverProfileCreateRequest.java
@@ -2,6 +2,7 @@ package com.patientpal.backend.caregiver.dto.request;
 
 import com.patientpal.backend.caregiver.domain.Caregiver;
 import com.patientpal.backend.member.domain.Address;
+import com.patientpal.backend.member.domain.Gender;
 import com.patientpal.backend.member.domain.Member;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -24,6 +25,9 @@ public class CaregiverProfileCreateRequest {
     private String phoneNumber;
 
     @NotNull
+    private Gender gender;
+
+    @NotNull
     private Address address;
 
     private float rating;
@@ -35,12 +39,13 @@ public class CaregiverProfileCreateRequest {
     private String caregiverSignificant;
 
     @Builder
-    public CaregiverProfileCreateRequest(String name, String residentRegistrationNumber, String phoneNumber,
+    public CaregiverProfileCreateRequest(String name, String residentRegistrationNumber, String phoneNumber, Gender gender,
                                          Address address, float rating, int experienceYears, String specialization,
                                          String caregiverSignificant) {
         this.name = name;
         this.residentRegistrationNumber = residentRegistrationNumber;
         this.phoneNumber = phoneNumber;
+        this.gender = gender;
         this.address = address;
         this.rating = rating;
         this.experienceYears = experienceYears;
@@ -52,7 +57,9 @@ public class CaregiverProfileCreateRequest {
         return Caregiver.builder()
                 .name(this.name)
                 .residentRegistrationNumber(this.residentRegistrationNumber)
+                .age(Caregiver.getAge(this.residentRegistrationNumber))
                 .member(member)
+                .gender(this.gender)
                 .address(this.address)
                 .phoneNumber(this.phoneNumber)
                 .rating(this.rating)

--- a/src/main/java/com/patientpal/backend/caregiver/dto/response/CaregiverProfileDetailResponse.java
+++ b/src/main/java/com/patientpal/backend/caregiver/dto/response/CaregiverProfileDetailResponse.java
@@ -1,0 +1,76 @@
+package com.patientpal.backend.caregiver.dto.response;
+
+import com.patientpal.backend.caregiver.domain.Caregiver;
+import com.patientpal.backend.member.domain.Address;
+import com.patientpal.backend.member.domain.Gender;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CaregiverProfileDetailResponse {
+
+    private Long memberId;
+
+    private String name;
+
+    private String residentRegistrationNumber;
+
+    private int age;
+
+    private String phoneNumber;
+
+    private Gender gender;
+
+    private Address address;
+
+    private float rating;
+
+    private int experienceYears;
+
+    private String specialization;
+
+    private String caregiverSignificant;
+
+    private Boolean isInMatchList;
+
+    private String image;
+
+    @Builder
+    public CaregiverProfileDetailResponse(Long memberId, String name, String residentRegistrationNumber, int age, String phoneNumber, Gender gender, Address address, float rating, int experienceYears,
+                                          String specialization, String caregiverSignificant, Boolean isInMatchList, String image) {
+        this.memberId = memberId;
+        this.name = name;
+        this.residentRegistrationNumber = residentRegistrationNumber;
+        this.age = age;
+        this.phoneNumber = phoneNumber;
+        this.gender = gender;
+        this.address = address;
+        this.rating = rating;
+        this.experienceYears = experienceYears;
+        this.specialization = specialization;
+        this.caregiverSignificant = caregiverSignificant;
+        this.isInMatchList = isInMatchList;
+        this.image = image;
+    }
+
+    public static CaregiverProfileDetailResponse of(Caregiver caregiver) {
+        return CaregiverProfileDetailResponse.builder()
+                .memberId(caregiver.getMember().getId())
+                .name(caregiver.getName())
+                .residentRegistrationNumber(caregiver.getResidentRegistrationNumber())
+                .age(Caregiver.getAge(caregiver.getResidentRegistrationNumber()))
+                .phoneNumber(caregiver.getPhoneNumber())
+                .gender(caregiver.getGender())
+                .address(caregiver.getAddress())
+                .rating(caregiver.getRating())
+                .experienceYears(caregiver.getExperienceYears())
+                .specialization(caregiver.getSpecialization())
+                .caregiverSignificant(caregiver.getCaregiverSignificant())
+                .isInMatchList(caregiver.getIsInMatchList())
+                .image(caregiver.getProfileImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/patientpal/backend/caregiver/dto/response/CaregiverProfileListResponse.java
+++ b/src/main/java/com/patientpal/backend/caregiver/dto/response/CaregiverProfileListResponse.java
@@ -1,0 +1,33 @@
+package com.patientpal.backend.caregiver.dto.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CaregiverProfileListResponse {
+
+    private List<CaregiverProfileResponse> caregiverProfileList;
+    private int currentPage;
+    private int totalPages;
+    private long totalItems;
+
+    public CaregiverProfileListResponse(List<CaregiverProfileResponse> caregiverProfileList, int currentPage, int totalPages, long totalItems) {
+        this.caregiverProfileList = caregiverProfileList;
+        this.currentPage = currentPage;
+        this.totalPages = totalPages;
+        this.totalItems = totalItems;
+    }
+
+    public static CaregiverProfileListResponse from(Page<CaregiverProfileResponse> search) {
+        return new CaregiverProfileListResponse(
+                search.getContent(),
+                search.getNumber(),
+                search.getTotalPages(),
+                search.getTotalElements()
+        );
+    }
+}

--- a/src/main/java/com/patientpal/backend/caregiver/dto/response/CaregiverProfileResponse.java
+++ b/src/main/java/com/patientpal/backend/caregiver/dto/response/CaregiverProfileResponse.java
@@ -1,9 +1,9 @@
 package com.patientpal.backend.caregiver.dto.response;
 
-import com.patientpal.backend.caregiver.domain.Caregiver;
 import com.patientpal.backend.member.domain.Address;
+import com.patientpal.backend.member.domain.Gender;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,13 +11,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CaregiverProfileResponse {
 
-    private Long memberId;
-
     private String name;
 
-    private String residentRegistrationNumber;
+    private int age;
 
-    private String phoneNumber;
+    private Gender gender;
 
     private Address address;
 
@@ -27,41 +25,18 @@ public class CaregiverProfileResponse {
 
     private String specialization;
 
-    private String caregiverSignificant;
-
-    private Boolean isInMatchList;
-
     private String image;
 
-    @Builder
-    public CaregiverProfileResponse(Long memberId, String name, String residentRegistrationNumber, String phoneNumber, Address address, float rating, int experienceYears,
-                                    String specialization, String caregiverSignificant, Boolean isInMatchList, String image) {
-        this.memberId = memberId;
+    @QueryProjection
+    public CaregiverProfileResponse(String name, int age, Gender gender, Address address, float rating,
+                                    int experienceYears, String specialization, String image) {
         this.name = name;
-        this.residentRegistrationNumber = residentRegistrationNumber;
-        this.phoneNumber = phoneNumber;
+        this.age = age;
+        this.gender = gender;
         this.address = address;
         this.rating = rating;
         this.experienceYears = experienceYears;
         this.specialization = specialization;
-        this.caregiverSignificant = caregiverSignificant;
-        this.isInMatchList = isInMatchList;
         this.image = image;
-    }
-
-    public static CaregiverProfileResponse of(Caregiver caregiver) {
-        return CaregiverProfileResponse.builder()
-                .memberId(caregiver.getMember().getId())
-                .name(caregiver.getName())
-                .residentRegistrationNumber(caregiver.getResidentRegistrationNumber())
-                .phoneNumber(caregiver.getPhoneNumber())
-                .address(caregiver.getAddress())
-                .rating(caregiver.getRating())
-                .experienceYears(caregiver.getExperienceYears())
-                .specialization(caregiver.getSpecialization())
-                .caregiverSignificant(caregiver.getCaregiverSignificant())
-                .isInMatchList(caregiver.getIsInMatchList())
-                .image(caregiver.getProfileImageUrl())
-                .build();
     }
 }

--- a/src/main/java/com/patientpal/backend/caregiver/repository/CaregiverProfileSearchRepositoryCustom.java
+++ b/src/main/java/com/patientpal/backend/caregiver/repository/CaregiverProfileSearchRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.patientpal.backend.caregiver.repository;
+
+import com.patientpal.backend.patient.dto.response.PatientProfileResponse;
+import com.patientpal.backend.common.querydsl.ProfileSearchCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CaregiverProfileSearchRepositoryCustom {
+
+    Page<PatientProfileResponse> searchPatientProfilesOrderBy(ProfileSearchCondition condition, Pageable pageable);
+}

--- a/src/main/java/com/patientpal/backend/caregiver/repository/CaregiverRepository.java
+++ b/src/main/java/com/patientpal/backend/caregiver/repository/CaregiverRepository.java
@@ -2,10 +2,10 @@ package com.patientpal.backend.caregiver.repository;
 
 import com.patientpal.backend.caregiver.domain.Caregiver;
 import com.patientpal.backend.member.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
-public interface CaregiverRepository extends JpaRepository<Caregiver, Long> {
+public interface CaregiverRepository extends JpaRepository<Caregiver, Long>, CaregiverProfileSearchRepositoryCustom {
     Optional<Caregiver> findByMember(Member member);
+
 }

--- a/src/main/java/com/patientpal/backend/caregiver/repository/CaregiverRepositoryImpl.java
+++ b/src/main/java/com/patientpal/backend/caregiver/repository/CaregiverRepositoryImpl.java
@@ -1,0 +1,102 @@
+package com.patientpal.backend.caregiver.repository;
+
+import static com.patientpal.backend.patient.domain.QPatient.patient;
+import static com.querydsl.core.types.Order.ASC;
+import static com.querydsl.core.types.Order.DESC;
+
+import com.patientpal.backend.member.domain.Gender;
+import com.patientpal.backend.patient.domain.Patient;
+import com.patientpal.backend.patient.dto.response.PatientProfileResponse;
+import com.patientpal.backend.patient.dto.response.QPatientProfileResponse;
+import com.patientpal.backend.common.querydsl.ProfileSearchCondition;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+
+@Slf4j
+public class CaregiverRepositoryImpl implements CaregiverProfileSearchRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public CaregiverRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    //TODO 정렬 방식 추후 추가
+    //가까운 순(default)
+    //후기 많은 순
+    //최신 순
+
+    @Override
+    public Page<PatientProfileResponse> searchPatientProfilesOrderBy(ProfileSearchCondition condition, Pageable pageable) {
+        log.info("Search Condition Name={}, gender={}, firstAddress={}, secondAddress={}",
+                condition.getName(), condition.getGender(), condition.getFirstAddress(), condition.getSecondAddress());
+
+        List<PatientProfileResponse> content = queryFactory
+                .select(new QPatientProfileResponse(
+                        patient.name,
+                        patient.age,
+                        patient.gender,
+                        patient.address,
+                        patient.profileImageUrl))
+                .from(patient)
+                .where(nameEq(condition.getName()),
+                        genderEq(condition.getGender()),
+                        firstAddressEq(condition.getFirstAddress()),
+                        secondAddressEq(condition.getSecondAddress()))
+                .orderBy(getOrderSpecifier(pageable.getSort()).stream().toArray(OrderSpecifier[]::new))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(patient.count())
+                .from(patient)
+                .where(nameEq(condition.getName()));
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private List<OrderSpecifier> getOrderSpecifier(Sort sort) {
+        List<OrderSpecifier> list = new ArrayList<>();
+        sort.stream().forEach(order -> {
+            Order direction = order.isAscending() ? ASC : DESC;
+            log.info("order:{}", order);
+            log.info("direction:{}", direction);
+            String property = order.getProperty();
+            log.info("property:{}", property);
+            PathBuilder orderByExpression = new PathBuilder(Patient.class, "patient");
+            log.info("orderByExpression:{}", orderByExpression);
+            list.add(new OrderSpecifier(direction, orderByExpression.get(property)));
+        });
+        return list;
+    }
+
+    private BooleanExpression genderEq(Gender gender) {
+        return gender == null ? null : patient.gender.eq(gender);
+    }
+
+    private BooleanExpression firstAddressEq(String firstAddress) {
+        return firstAddress == null ? null : patient.address.addr.contains(firstAddress);
+    }
+
+    private BooleanExpression secondAddressEq(String secondAddress) {
+        return secondAddress == null ? null : patient.address.addr.contains(secondAddress);
+    }
+
+    private BooleanExpression nameEq(String name) {
+        return StringUtils.isEmpty(name) ? null : patient.name.eq(name);
+    }
+}

--- a/src/main/java/com/patientpal/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/patientpal/backend/common/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AU_001", "이메일 또는 비밀번호가 일치하지 않습니다."),
 
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "V_001", "유효하지 않은 토큰입니다."),
+    INVALID_RESIDENT_REGISTRATION_NUMBER(HttpStatus.NON_AUTHORITATIVE_INFORMATION, "V_002", "유효하지 않은 주민등록번호입니다."),
 
     MEMBER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "M_001", "이미 가입된 계정이 존재합니다."),
     MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST, "M_002", "해당 멤버는 존재하지 않습니다."),

--- a/src/main/java/com/patientpal/backend/common/querydsl/ProfileSearchCondition.java
+++ b/src/main/java/com/patientpal/backend/common/querydsl/ProfileSearchCondition.java
@@ -1,0 +1,27 @@
+package com.patientpal.backend.common.querydsl;
+
+import com.patientpal.backend.member.domain.Gender;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ProfileSearchCondition {
+
+    //TODO
+    //가까운 순 정렬 -> 경도 위도 따야하나
+    //후기 많은 순
+    //최신 순
+
+    private String firstAddress;
+    private String secondAddress;
+
+    private Gender gender;
+
+    private String name;
+
+    private Integer experienceYearsGoe;
+
+    // TODO 이후 프로필 주민번호 기반으로 나이 계산 후 추가
+    // private Integer ageLoe;
+}

--- a/src/main/java/com/patientpal/backend/member/domain/Address.java
+++ b/src/main/java/com/patientpal/backend/member/domain/Address.java
@@ -1,25 +1,22 @@
 package com.patientpal.backend.member.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import static jakarta.persistence.FetchType.*;
 
 @Embeddable
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Address {
 
-    private String street;
-    private String city;
+    private String addr;
+    private String addrDetail;
     private String zipCode;
 
-    public Address(String city, String street, String zipCode) {
-        this.city = city;
-        this.street = street;
+    public Address(String zipCode, String addr, String addrDetail) {
+        this.addr = addr;
+        this.addrDetail = addrDetail;
         this.zipCode = zipCode;
     }
-
 }

--- a/src/main/java/com/patientpal/backend/patient/domain/Patient.java
+++ b/src/main/java/com/patientpal/backend/patient/domain/Patient.java
@@ -1,16 +1,21 @@
 package com.patientpal.backend.patient.domain;
 
+import static com.patientpal.backend.common.exception.ErrorCode.INVALID_RESIDENT_REGISTRATION_NUMBER;
 import static jakarta.persistence.FetchType.LAZY;
 
 import com.patientpal.backend.common.BaseTimeEntity;
+import com.patientpal.backend.common.exception.InvalidValueException;
 import com.patientpal.backend.matching.domain.Match;
 import com.patientpal.backend.member.domain.Address;
+import com.patientpal.backend.member.domain.Gender;
 import com.patientpal.backend.member.domain.Member;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -19,6 +24,9 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -51,6 +59,8 @@ public class Patient extends BaseTimeEntity {
     @Column(unique = true)
     private String residentRegistrationNumber;
 
+    private int age;
+
     @Column(nullable = false, unique = true)
     private String phoneNumber;
 
@@ -58,6 +68,9 @@ public class Patient extends BaseTimeEntity {
     private Address address;
 
     private String nokName; //보호자 이름
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
 
     private String nokContact;
 
@@ -75,12 +88,14 @@ public class Patient extends BaseTimeEntity {
     private String profileImageUrl;
 
     @Builder
-    public Patient(Member member, String name, String residentRegistrationNumber, String phoneNumber, Address address,
+    public Patient(Member member, String name, String residentRegistrationNumber, Gender gender, String phoneNumber, int age, Address address,
                    String nokName, String nokContact, String patientSignificant, String careRequirements, Boolean isInMatchList, String profileImageUrl) {
         this.member = member;
         this.name = name;
         this.residentRegistrationNumber = residentRegistrationNumber;
+        this.gender = gender;
         this.phoneNumber = phoneNumber;
+        this.age = age;
         this.address = address;
         this.nokName = nokName;
         this.nokContact = nokContact;
@@ -104,5 +119,29 @@ public class Patient extends BaseTimeEntity {
 
     public void updateProfileImage(String profileImageUrl) {
         this.profileImageUrl = profileImageUrl;
+    }
+
+    public static int getAge(String rrn) {
+        String birthDateString = rrn.substring(0, 6);
+        int century;
+
+        char genderCode = rrn.charAt(7);
+        if (genderCode == '1' || genderCode == '2' || genderCode == '5' || genderCode == '6') {
+            century = 1900;
+        } else if (genderCode == '3' || genderCode == '4' || genderCode == '7' || genderCode == '8') {
+            century = 2000;
+        } else {
+            throw new InvalidValueException(INVALID_RESIDENT_REGISTRATION_NUMBER);
+        }
+
+        String birthYear = String.valueOf(century + Integer.parseInt(birthDateString.substring(0, 2)));
+        String birthMonthDay = birthDateString.substring(2);
+        String fullBirthDateString = birthYear + birthMonthDay;
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+        LocalDate birthDate = LocalDate.parse(fullBirthDateString, formatter);
+
+        LocalDate currentDate = LocalDate.now();
+        return Period.between(birthDate, currentDate).getYears();
     }
 }

--- a/src/main/java/com/patientpal/backend/patient/dto/request/PatientProfileCreateRequest.java
+++ b/src/main/java/com/patientpal/backend/patient/dto/request/PatientProfileCreateRequest.java
@@ -1,6 +1,7 @@
 package com.patientpal.backend.patient.dto.request;
 
 import com.patientpal.backend.member.domain.Address;
+import com.patientpal.backend.member.domain.Gender;
 import com.patientpal.backend.member.domain.Member;
 import com.patientpal.backend.patient.domain.Patient;
 import jakarta.validation.constraints.NotNull;
@@ -19,6 +20,9 @@ public class PatientProfileCreateRequest {
     @NotNull
     private String residentRegistrationNumber;
 
+    @NotNull
+    private Gender gender;
+
     //TODO 인증
     @NotNull
     private String phoneNumber;
@@ -36,9 +40,11 @@ public class PatientProfileCreateRequest {
     private String careRequirements;
 
     @Builder
-    public PatientProfileCreateRequest(String name, String residentRegistrationNumber, String phoneNumber, Address address, String nokName, String nokContact, String patientSignificant, String careRequirements) {
+    public PatientProfileCreateRequest(String name, String residentRegistrationNumber, String phoneNumber, Address address,
+                                       String nokName, String nokContact, String patientSignificant, String careRequirements, Gender gender) {
         this.name = name;
         this.residentRegistrationNumber = residentRegistrationNumber;
+        this.gender = gender;
         this.phoneNumber = phoneNumber;
         this.address = address;
         this.nokName = nokName;
@@ -51,7 +57,9 @@ public class PatientProfileCreateRequest {
         return Patient.builder()
                 .name(this.name)
                 .residentRegistrationNumber(this.residentRegistrationNumber)
+                .age(Patient.getAge(this.residentRegistrationNumber))
                 .member(member)
+                .gender(this.gender)
                 .phoneNumber(this.phoneNumber)
                 .address(this.address)
                 .nokName(this.nokName)

--- a/src/main/java/com/patientpal/backend/patient/dto/response/PatientProfileDetailResponse.java
+++ b/src/main/java/com/patientpal/backend/patient/dto/response/PatientProfileDetailResponse.java
@@ -1,0 +1,76 @@
+package com.patientpal.backend.patient.dto.response;
+
+import com.patientpal.backend.member.domain.Address;
+import com.patientpal.backend.member.domain.Gender;
+import com.patientpal.backend.patient.domain.Patient;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PatientProfileDetailResponse {
+
+    private Long memberId;
+
+    private String name;
+
+    private String residentRegistrationNumber;
+
+    private int age;
+
+    private String phoneNumber;
+
+    private Gender gender;
+
+    private Address address;
+
+    private String nokName;
+
+    private String nokContact;
+
+    private String patientSignificant;
+
+    private String careRequirements;
+
+    private Boolean isInMatchList;
+
+    private String image;
+
+    @Builder
+    public PatientProfileDetailResponse(Long memberId, String name, String residentRegistrationNumber, String phoneNumber, Gender gender, int age, Address address, String nokName, String nokContact,
+                                        String patientSignificant, String careRequirements, Boolean isInMatchList, String image) {
+        this.memberId = memberId;
+        this.name = name;
+        this.residentRegistrationNumber = residentRegistrationNumber;
+        this.phoneNumber = phoneNumber;
+        this.gender = gender;
+        this.age = age;
+        this.address = address;
+        this.nokName = nokName;
+        this.nokContact = nokContact;
+        this.patientSignificant = patientSignificant;
+        this.careRequirements = careRequirements;
+        this.isInMatchList = isInMatchList;
+        this.image = image;
+    }
+
+    public static PatientProfileDetailResponse of(Patient patient) {
+        return PatientProfileDetailResponse.builder()
+                .memberId(patient.getMember().getId())
+                .name(patient.getName())
+                .residentRegistrationNumber(patient.getResidentRegistrationNumber())
+                .age(patient.getAge())
+                .phoneNumber(patient.getPhoneNumber())
+                .gender(patient.getGender())
+                .address(patient.getAddress())
+                .nokName(patient.getNokName())
+                .nokContact(patient.getNokContact())
+                .patientSignificant(patient.getPatientSignificant())
+                .careRequirements(patient.getCareRequirements())
+                .isInMatchList(patient.getIsInMatchList())
+                .image(patient.getProfileImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/patientpal/backend/patient/dto/response/PatientProfileListResponse.java
+++ b/src/main/java/com/patientpal/backend/patient/dto/response/PatientProfileListResponse.java
@@ -1,0 +1,33 @@
+package com.patientpal.backend.patient.dto.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PatientProfileListResponse {
+
+    private List<PatientProfileResponse> patientProfileList;
+    private int currentPage;
+    private int totalPages;
+    private long totalItems;
+
+    public PatientProfileListResponse(List<PatientProfileResponse> patientProfileList, int currentPage, int totalPages, long totalItems) {
+        this.patientProfileList = patientProfileList;
+        this.currentPage = currentPage;
+        this.totalPages = totalPages;
+        this.totalItems = totalItems;
+    }
+
+    public static PatientProfileListResponse from(Page<PatientProfileResponse> search) {
+        return new PatientProfileListResponse(
+                search.getContent(),
+                search.getNumber(),
+                search.getTotalPages(),
+                search.getTotalElements()
+        );
+    }
+}

--- a/src/main/java/com/patientpal/backend/patient/dto/response/PatientProfileResponse.java
+++ b/src/main/java/com/patientpal/backend/patient/dto/response/PatientProfileResponse.java
@@ -1,7 +1,8 @@
 package com.patientpal.backend.patient.dto.response;
 
 import com.patientpal.backend.member.domain.Address;
-import com.patientpal.backend.patient.domain.Patient;
+import com.patientpal.backend.member.domain.Gender;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,57 +12,23 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PatientProfileResponse {
 
-    private Long memberId;
-
     private String name;
 
-    private String residentRegistrationNumber;
+    private int age;
 
-    private String phoneNumber;
+    private Gender gender;
 
     private Address address;
-
-    private String nokName;
-
-    private String nokContact;
-
-    private String patientSignificant;
-
-    private String careRequirements;
-
-    private Boolean isInMatchList;
 
     private String image;
 
     @Builder
-    public PatientProfileResponse(Long memberId, String name, String residentRegistrationNumber, String phoneNumber, Address address, String nokName, String nokContact,
-                                  String patientSignificant, String careRequirements, Boolean isInMatchList, String image) {
-        this.memberId = memberId;
+    @QueryProjection
+    public PatientProfileResponse(String name, int age, Gender gender, Address address, String image) {
         this.name = name;
-        this.residentRegistrationNumber = residentRegistrationNumber;
-        this.phoneNumber = phoneNumber;
+        this.age = age;
+        this.gender = gender;
         this.address = address;
-        this.nokName = nokName;
-        this.nokContact = nokContact;
-        this.patientSignificant = patientSignificant;
-        this.careRequirements = careRequirements;
-        this.isInMatchList = isInMatchList;
         this.image = image;
-    }
-
-    public static PatientProfileResponse of(Patient patient) {
-        return PatientProfileResponse.builder()
-                .memberId(patient.getMember().getId())
-                .name(patient.getName())
-                .residentRegistrationNumber(patient.getResidentRegistrationNumber())
-                .phoneNumber(patient.getPhoneNumber())
-                .address(patient.getAddress())
-                .nokName(patient.getNokName())
-                .nokContact(patient.getNokContact())
-                .patientSignificant(patient.getPatientSignificant())
-                .careRequirements(patient.getCareRequirements())
-                .isInMatchList(patient.getIsInMatchList())
-                .image(patient.getProfileImageUrl())
-                .build();
     }
 }

--- a/src/main/java/com/patientpal/backend/patient/repository/PatientProfileSearchRepositoryCustom.java
+++ b/src/main/java/com/patientpal/backend/patient/repository/PatientProfileSearchRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.patientpal.backend.patient.repository;
+
+import com.patientpal.backend.caregiver.dto.response.CaregiverProfileResponse;
+import com.patientpal.backend.common.querydsl.ProfileSearchCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PatientProfileSearchRepositoryCustom {
+
+    Page<CaregiverProfileResponse> searchCaregiverProfilesOrderBy(ProfileSearchCondition condition, Pageable pageable);
+}

--- a/src/main/java/com/patientpal/backend/patient/repository/PatientRepository.java
+++ b/src/main/java/com/patientpal/backend/patient/repository/PatientRepository.java
@@ -2,10 +2,9 @@ package com.patientpal.backend.patient.repository;
 
 import com.patientpal.backend.member.domain.Member;
 import com.patientpal.backend.patient.domain.Patient;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
-public interface PatientRepository extends JpaRepository<Patient, Long> {
+public interface PatientRepository extends JpaRepository<Patient, Long>, PatientProfileSearchRepositoryCustom {
     Optional<Patient> findByMember(Member member);
 }

--- a/src/main/java/com/patientpal/backend/patient/repository/PatientRepositoryImpl.java
+++ b/src/main/java/com/patientpal/backend/patient/repository/PatientRepositoryImpl.java
@@ -1,0 +1,112 @@
+package com.patientpal.backend.patient.repository;
+
+import static com.patientpal.backend.caregiver.domain.QCaregiver.caregiver;
+import static com.querydsl.core.types.Order.ASC;
+import static com.querydsl.core.types.Order.DESC;
+
+import com.patientpal.backend.caregiver.domain.Caregiver;
+import com.patientpal.backend.caregiver.dto.response.CaregiverProfileResponse;
+import com.patientpal.backend.caregiver.dto.response.QCaregiverProfileResponse;
+import com.patientpal.backend.member.domain.Gender;
+import com.patientpal.backend.common.querydsl.ProfileSearchCondition;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+
+@Slf4j
+public class PatientRepositoryImpl implements PatientProfileSearchRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public PatientRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    //TODO 정렬 방식 추후 추가
+    //가까운 순(default)
+    //후기 많은 순
+    //최신 순
+
+    @Override
+    public Page<CaregiverProfileResponse> searchCaregiverProfilesOrderBy(ProfileSearchCondition condition, Pageable pageable) {
+        log.info("Search Condition Name={}, experienceYears={}, gender={}, firstAddress={}, secondAddress={}",
+                condition.getName(), condition.getExperienceYearsGoe(),
+                condition.getGender(), condition.getFirstAddress(), condition.getSecondAddress());
+
+
+        List<CaregiverProfileResponse> content = queryFactory
+                .select(new QCaregiverProfileResponse(
+                        caregiver.name,
+                        caregiver.age,
+                        caregiver.gender,
+                        caregiver.address,
+                        caregiver.rating,
+                        caregiver.experienceYears,
+                        caregiver.specialization,
+                        caregiver.profileImageUrl))
+                .from(caregiver)
+                .where(nameEq(condition.getName()),
+                        genderEq(condition.getGender()),
+                        firstAddressEq(condition.getFirstAddress()),
+                        secondAddressEq(condition.getSecondAddress()),
+                        experienceYearsGoe(condition.getExperienceYearsGoe()))
+                .orderBy(getOrderSpecifier(pageable.getSort()).stream().toArray(OrderSpecifier[]::new))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(caregiver.count())
+                .from(caregiver)
+                .where(nameEq(condition.getName()));
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private List<OrderSpecifier> getOrderSpecifier(Sort sort) {
+        List<OrderSpecifier> list = new ArrayList<>();
+        sort.stream().forEach(order -> {
+            Order direction = order.isAscending() ? ASC : DESC;
+            log.info("order:{}", order);
+            log.info("direction:{}", direction);
+            String property = order.getProperty();
+            log.info("property:{}", property);
+            PathBuilder orderByExpression = new PathBuilder(Caregiver.class, "caregiver");
+            log.info("orderByExpression:{}", orderByExpression);
+            list.add(new OrderSpecifier(direction, orderByExpression.get(property)));
+        });
+        return list;
+    }
+
+    private BooleanExpression genderEq(Gender gender) {
+        return gender == null ? null : caregiver.gender.eq(gender);
+    }
+
+    private BooleanExpression experienceYearsGoe(Integer experienceYears) {
+        return experienceYears == null ? null : caregiver.experienceYears.goe(experienceYears);
+    }
+
+    private BooleanExpression firstAddressEq(String firstAddress) {
+        return firstAddress == null ? null : caregiver.address.addr.contains(firstAddress);
+    }
+
+    private BooleanExpression secondAddressEq(String secondAddress) {
+        return secondAddress == null ? null : caregiver.address.addr.contains(secondAddress);
+    }
+
+    private BooleanExpression nameEq(String name) {
+        return StringUtils.isEmpty(name) ? null : caregiver.name.eq(name);
+    }
+}

--- a/src/main/java/com/patientpal/backend/patient/service/PatientService.java
+++ b/src/main/java/com/patientpal/backend/patient/service/PatientService.java
@@ -1,5 +1,7 @@
 package com.patientpal.backend.patient.service;
 
+import com.patientpal.backend.caregiver.dto.response.CaregiverProfileListResponse;
+import com.patientpal.backend.caregiver.dto.response.CaregiverProfileResponse;
 import com.patientpal.backend.common.exception.AuthorizationException;
 import com.patientpal.backend.common.exception.EntityNotFoundException;
 import com.patientpal.backend.common.exception.ErrorCode;
@@ -12,10 +14,13 @@ import com.patientpal.backend.member.repository.MemberRepository;
 import com.patientpal.backend.patient.domain.Patient;
 import com.patientpal.backend.patient.dto.request.PatientProfileCreateRequest;
 import com.patientpal.backend.patient.dto.request.PatientProfileUpdateRequest;
-import com.patientpal.backend.patient.dto.response.PatientProfileResponse;
+import com.patientpal.backend.patient.dto.response.PatientProfileDetailResponse;
 import com.patientpal.backend.patient.repository.PatientRepository;
+import com.patientpal.backend.common.querydsl.ProfileSearchCondition;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,11 +31,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class PatientService {
 
     private final PatientRepository patientRepository;
+
     private final MemberRepository memberRepository;
     private final MatchRepository matchRepository;
 
     @Transactional
-    public PatientProfileResponse savePatientProfile(String username, PatientProfileCreateRequest patientProfileCreateRequest, String profileImageUrl) {
+    public PatientProfileDetailResponse savePatientProfile(String username, PatientProfileCreateRequest patientProfileCreateRequest, String profileImageUrl) {
         Member currentMember = getMember(username);
         // TODO 본인 인증 시, 중복 가입이면 throw
         validateAuthorization(currentMember);
@@ -38,7 +44,7 @@ public class PatientService {
         Patient savedPatient = patientRepository.save(
                 patientProfileCreateRequest.toEntity(currentMember, profileImageUrl));
         log.info("프로필 등록 성공: ID={}, NAME={}", savedPatient.getId(), savedPatient.getName());
-        return PatientProfileResponse.of(savedPatient);
+        return PatientProfileDetailResponse.of(savedPatient);
     }
 
     private void validateAuthorization(Member currentMember) {
@@ -53,10 +59,10 @@ public class PatientService {
         });
     }
 
-    public PatientProfileResponse getProfile(String username) {
+    public PatientProfileDetailResponse getProfile(String username) {
         Member currentMember = getMember(username);
         Patient patient = getPatient(currentMember);
-        return PatientProfileResponse.of(patient);
+        return PatientProfileDetailResponse.of(patient);
     }
 
     @Transactional
@@ -129,4 +135,8 @@ public class PatientService {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.PATIENT_NOT_EXIST));
     }
 
+    public CaregiverProfileListResponse searchPageOrderBy(ProfileSearchCondition condition, Pageable pageable) {
+        Page<CaregiverProfileResponse> search = patientRepository.searchCaregiverProfilesOrderBy(condition, pageable);
+        return CaregiverProfileListResponse.from(search);
+    }
 }

--- a/src/test/java/com/patientpal/backend/caregiver/controller/CaregiverControllerV1Test.java
+++ b/src/test/java/com/patientpal/backend/caregiver/controller/CaregiverControllerV1Test.java
@@ -17,10 +17,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.patientpal.backend.caregiver.dto.request.CaregiverProfileCreateRequest;
 import com.patientpal.backend.caregiver.dto.request.CaregiverProfileUpdateRequest;
-import com.patientpal.backend.caregiver.dto.response.CaregiverProfileResponse;
+import com.patientpal.backend.caregiver.dto.response.CaregiverProfileDetailResponse;
 import com.patientpal.backend.caregiver.service.CaregiverService;
 import com.patientpal.backend.common.exception.EntityNotFoundException;
 import com.patientpal.backend.common.exception.ErrorCode;
+import com.patientpal.backend.member.domain.Address;
 import com.patientpal.backend.test.CommonControllerSliceTest;
 import com.patientpal.backend.test.annotation.AutoKoreanDisplayName;
 import com.patientpal.backend.test.annotation.WithCustomMockUserCaregiver;
@@ -44,7 +45,7 @@ class CaregiverControllerV1Test extends CommonControllerSliceTest {
         void 성공한다() throws Exception {
             // given
             CaregiverProfileCreateRequest request = createCaregiverProfileRequest();
-            CaregiverProfileResponse response = createCaregiverProfileResponse();
+            CaregiverProfileDetailResponse response = createCaregiverProfileResponse();
             given(caregiverService.saveCaregiverProfile(any(String.class), any(CaregiverProfileCreateRequest.class), any())).willReturn(response);
 
             // when & then
@@ -55,15 +56,14 @@ class CaregiverControllerV1Test extends CommonControllerSliceTest {
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.name").value(response.getName()))
                     .andExpect(jsonPath("$.residentRegistrationNumber").value(response.getResidentRegistrationNumber()))
-                    .andExpect(jsonPath("$.phoneNumber").value(response.getPhoneNumber()))
-                    .andExpect(jsonPath("$.address.street").value(response.getAddress().getStreet()));
+                    .andExpect(jsonPath("$.phoneNumber").value(response.getPhoneNumber()));
         }
 
         @Test
         @WithCustomMockUserCaregiver
         void 잘못된_요청이면_예외가_발생한다() throws Exception {
             // given
-            CaregiverProfileCreateRequest request = new CaregiverProfileCreateRequest("", "", "", null, 0, 1, "", "");
+            CaregiverProfileCreateRequest request = new CaregiverProfileCreateRequest("", "", "", null, new Address("hi", "ho", "ha"), 1, 1, "", "");
 
             // when & then
             mockMvc.perform(post("/api/v1/caregiver")
@@ -81,7 +81,7 @@ class CaregiverControllerV1Test extends CommonControllerSliceTest {
         @WithCustomMockUserCaregiver
         void 성공한다() throws Exception {
             // given
-            CaregiverProfileResponse response = createCaregiverProfileResponse();
+            CaregiverProfileDetailResponse response = createCaregiverProfileResponse();
             given(caregiverService.getProfile(any(String.class))).willReturn(response);
 
             // when & then
@@ -90,8 +90,7 @@ class CaregiverControllerV1Test extends CommonControllerSliceTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.name").value(response.getName()))
                     .andExpect(jsonPath("$.residentRegistrationNumber").value(response.getResidentRegistrationNumber()))
-                    .andExpect(jsonPath("$.phoneNumber").value(response.getPhoneNumber()))
-                    .andExpect(jsonPath("$.address.street").value(response.getAddress().getStreet()));
+                    .andExpect(jsonPath("$.phoneNumber").value(response.getPhoneNumber()));
         }
 
         @Test

--- a/src/test/java/com/patientpal/backend/caregiver/service/CaregiverServiceTest.java
+++ b/src/test/java/com/patientpal/backend/caregiver/service/CaregiverServiceTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.when;
 import com.patientpal.backend.caregiver.domain.Caregiver;
 import com.patientpal.backend.caregiver.dto.request.CaregiverProfileCreateRequest;
 import com.patientpal.backend.caregiver.dto.request.CaregiverProfileUpdateRequest;
-import com.patientpal.backend.caregiver.dto.response.CaregiverProfileResponse;
+import com.patientpal.backend.caregiver.dto.response.CaregiverProfileDetailResponse;
 import com.patientpal.backend.caregiver.repository.CaregiverRepository;
 import com.patientpal.backend.common.exception.AuthorizationException;
 import com.patientpal.backend.common.exception.EntityNotFoundException;
@@ -64,7 +64,7 @@ class CaregiverServiceTest {
             CaregiverProfileCreateRequest request = createCaregiverProfileRequest();
 
             // when
-            CaregiverProfileResponse response = caregiverService.saveCaregiverProfile(member.getUsername(), request, any(String.class));
+            CaregiverProfileDetailResponse response = caregiverService.saveCaregiverProfile(member.getUsername(), request, any(String.class));
 
             // then
             assertNotNull(response);
@@ -117,7 +117,7 @@ class CaregiverServiceTest {
             when(caregiverRepository.findByMember(caregiver.getMember())).thenReturn(Optional.of(caregiver));
 
             // when
-            CaregiverProfileResponse response = caregiverService.getProfile(caregiver.getMember().getUsername());
+            CaregiverProfileDetailResponse response = caregiverService.getProfile(caregiver.getMember().getUsername());
 
             // then
             assertNotNull(response);

--- a/src/test/java/com/patientpal/backend/fixtures/caregiver/CaregiverFixture.java
+++ b/src/test/java/com/patientpal/backend/fixtures/caregiver/CaregiverFixture.java
@@ -10,8 +10,9 @@ import static com.patientpal.backend.fixtures.member.MemberFixture.jeonghyeRoleC
 import com.patientpal.backend.caregiver.domain.Caregiver;
 import com.patientpal.backend.caregiver.dto.request.CaregiverProfileCreateRequest;
 import com.patientpal.backend.caregiver.dto.request.CaregiverProfileUpdateRequest;
-import com.patientpal.backend.caregiver.dto.response.CaregiverProfileResponse;
+import com.patientpal.backend.caregiver.dto.response.CaregiverProfileDetailResponse;
 import com.patientpal.backend.member.domain.Address;
+import com.patientpal.backend.member.domain.Gender;
 
 public class CaregiverFixture {
 
@@ -76,6 +77,7 @@ public class CaregiverFixture {
         return CaregiverProfileCreateRequest.builder()
                 .name(HUSEONG_NAME)
                 .residentRegistrationNumber(RESIDENT_REGISTRATION_NUMBER)
+                .gender(Gender.MALE)
                 .phoneNumber(PHONE_NUMBER)
                 .address(ADDRESS)
                 .rating(RATING)
@@ -95,8 +97,8 @@ public class CaregiverFixture {
                 .build();
     }
 
-    public static CaregiverProfileResponse createCaregiverProfileResponse() {
-        return CaregiverProfileResponse.builder()
+    public static CaregiverProfileDetailResponse createCaregiverProfileResponse() {
+        return CaregiverProfileDetailResponse.builder()
                 .memberId(1L)
                 .name(HUSEONG_NAME)
                 .residentRegistrationNumber(RESIDENT_REGISTRATION_NUMBER)

--- a/src/test/java/com/patientpal/backend/fixtures/patient/PatientFixture.java
+++ b/src/test/java/com/patientpal/backend/fixtures/patient/PatientFixture.java
@@ -6,10 +6,11 @@ import static com.patientpal.backend.fixtures.member.MemberFixture.jeonghyeRoleP
 
 import com.patientpal.backend.fixtures.member.MemberFixture;
 import com.patientpal.backend.member.domain.Address;
+import com.patientpal.backend.member.domain.Gender;
 import com.patientpal.backend.patient.domain.Patient;
 import com.patientpal.backend.patient.dto.request.PatientProfileCreateRequest;
 import com.patientpal.backend.patient.dto.request.PatientProfileUpdateRequest;
-import com.patientpal.backend.patient.dto.response.PatientProfileResponse;
+import com.patientpal.backend.patient.dto.response.PatientProfileDetailResponse;
 
 public class PatientFixture {
 
@@ -63,6 +64,7 @@ public class PatientFixture {
         return PatientProfileCreateRequest.builder()
                 .phoneNumber(PATIENT_PHONE_NUMBER)
                 .residentRegistrationNumber(RESIDENT_REGISTRATION_NUMBER)
+                .gender(Gender.MALE)
                 .name(MemberFixture.HUSEONG_NAME)
                 .address(PATIENT_ADDRESS)
                 .nokName(NOK_NAME)
@@ -80,8 +82,8 @@ public class PatientFixture {
                 .build();
     }
 
-    public static PatientProfileResponse createPatientProfileResponse() {
-        return PatientProfileResponse.builder()
+    public static PatientProfileDetailResponse createPatientProfileResponse() {
+        return PatientProfileDetailResponse.builder()
                 .memberId(1L)
                 .phoneNumber(PATIENT_PHONE_NUMBER)
                 .address(PATIENT_ADDRESS)

--- a/src/test/java/com/patientpal/backend/patient/controller/PatientControllerV1Test.java
+++ b/src/test/java/com/patientpal/backend/patient/controller/PatientControllerV1Test.java
@@ -15,12 +15,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.patientpal.backend.member.domain.Gender;
 import com.patientpal.backend.test.annotation.WithCustomMockUserPatient;
 import com.patientpal.backend.common.exception.EntityNotFoundException;
 import com.patientpal.backend.common.exception.ErrorCode;
 import com.patientpal.backend.patient.dto.request.PatientProfileCreateRequest;
 import com.patientpal.backend.patient.dto.request.PatientProfileUpdateRequest;
-import com.patientpal.backend.patient.dto.response.PatientProfileResponse;
+import com.patientpal.backend.patient.dto.response.PatientProfileDetailResponse;
 import com.patientpal.backend.patient.service.PatientService;
 import com.patientpal.backend.test.CommonControllerSliceTest;
 import com.patientpal.backend.test.annotation.AutoKoreanDisplayName;
@@ -44,7 +45,7 @@ public class PatientControllerV1Test extends CommonControllerSliceTest {
         void 성공한다() throws Exception {
             // given
             PatientProfileCreateRequest request = createPatientProfileRequest();
-            PatientProfileResponse response = createPatientProfileResponse();
+            PatientProfileDetailResponse response = createPatientProfileResponse();
             given(patientService.savePatientProfile(any(String.class), any(PatientProfileCreateRequest.class), any())).willReturn(response);
 
             // when & then
@@ -55,15 +56,15 @@ public class PatientControllerV1Test extends CommonControllerSliceTest {
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.name").value(response.getName()))
                     .andExpect(jsonPath("$.residentRegistrationNumber").value(response.getResidentRegistrationNumber()))
-                    .andExpect(jsonPath("$.phoneNumber").value(response.getPhoneNumber()))
-                    .andExpect(jsonPath("$.address.street").value(response.getAddress().getStreet()));
+                    .andExpect(jsonPath("$.phoneNumber").value(response.getPhoneNumber()));
         }
 
         @Test
         @WithCustomMockUserPatient
         void 잘못된_요청이면_예외가_발생한다() throws Exception {
             // given
-            PatientProfileCreateRequest request = new PatientProfileCreateRequest("", "", "", null, "", "", "", "");
+            PatientProfileCreateRequest request = new PatientProfileCreateRequest("", "", "", null, "", "", "", "",
+                    Gender.MALE);
 
             // when & then
             mockMvc.perform(post("/api/v1/patient")
@@ -81,7 +82,7 @@ public class PatientControllerV1Test extends CommonControllerSliceTest {
         @WithCustomMockUserPatient
         void 성공한다() throws Exception {
             // given
-            PatientProfileResponse response = createPatientProfileResponse();
+            PatientProfileDetailResponse response = createPatientProfileResponse();
             given(patientService.getProfile(any(String.class))).willReturn(response);
 
             // when & then
@@ -90,8 +91,7 @@ public class PatientControllerV1Test extends CommonControllerSliceTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.name").value(response.getName()))
                     .andExpect(jsonPath("$.residentRegistrationNumber").value(response.getResidentRegistrationNumber()))
-                    .andExpect(jsonPath("$.phoneNumber").value(response.getPhoneNumber()))
-                    .andExpect(jsonPath("$.address.street").value(response.getAddress().getStreet()));
+                    .andExpect(jsonPath("$.phoneNumber").value(response.getPhoneNumber()));
         }
 
         @Test

--- a/src/test/java/com/patientpal/backend/patient/service/PatientServiceTest.java
+++ b/src/test/java/com/patientpal/backend/patient/service/PatientServiceTest.java
@@ -23,7 +23,7 @@ import com.patientpal.backend.member.repository.MemberRepository;
 import com.patientpal.backend.patient.domain.Patient;
 import com.patientpal.backend.patient.dto.request.PatientProfileCreateRequest;
 import com.patientpal.backend.patient.dto.request.PatientProfileUpdateRequest;
-import com.patientpal.backend.patient.dto.response.PatientProfileResponse;
+import com.patientpal.backend.patient.dto.response.PatientProfileDetailResponse;
 import com.patientpal.backend.patient.repository.PatientRepository;
 import com.patientpal.backend.test.annotation.AutoKoreanDisplayName;
 import java.util.Optional;
@@ -64,7 +64,7 @@ class PatientServiceTest {
             PatientProfileCreateRequest request = createPatientProfileRequest();
 
             // when
-            PatientProfileResponse response = patientService.savePatientProfile(member.getUsername(), request, any(String.class));
+            PatientProfileDetailResponse response = patientService.savePatientProfile(member.getUsername(), request, any(String.class));
 
             // then
             assertNotNull(response);
@@ -117,7 +117,7 @@ class PatientServiceTest {
             when(patientRepository.findByMember(patient.getMember())).thenReturn(Optional.of(patient));
 
             // when
-            PatientProfileResponse response = patientService.getProfile(patient.getMember().getUsername());
+            PatientProfileDetailResponse response = patientService.getProfile(patient.getMember().getUsername());
 
             // then
             assertNotNull(response);


### PR DESCRIPTION
<!-- 적절히 쪼개서 PR을 작성해주세요. 리뷰어가 한 번에 너무 많은 코드를 검토하면 읽기 어렵고 코드의 결함을 찾기 힘들어질 수 있어요! 😊 -->
## ✨ 작업 내용
- 환자 -> 간병인 찾기 기능 추가 (필터, 정렬 가능)
- 간병인 -> 환자 찾기 기능 추가 (필터, 정렬 가능)
- CaregiverProfileResponse(리스트에서 볼 프로필), CaregiverProfileDetailResponse(세부 프로필) DTO 분리
- QueryDSL 관련 설정 gradle 추가
- 프로필 필드에 Gender, Age 추가 (리스트 검색 시 볼 수 있게)
- Address 다음 주소 API 형식으로 수정

<!-- 이 PR과 관련된 이슈 번호를 명시해주세요. 🔢 -->
<!-- 예를 들어, #123 형식으로 작성해주시고, 닫으려는 이슈가 있다면 "Fixes #123" 또는 "Closes #123" 형식으로 작성해주시면 PR이 머지될 때 해당 이슈가 자동으로 닫힙니다. -->
## 🔗 관련 이슈
- Closes #91 

<!-- 관련된 문서나 참고한 자료 링크를 추가해주세요! 🌐 -->
## 📚 레퍼런스
- https://yongc.tistory.com/81
