### PR TITLE
Feat: 게시글 Update, Delete 함수 실행시 member 를 검사하도록 수정

### DIFF
--- a/src/main/java/com/patientpal/backend/post/controller/BoardController.java
+++ b/src/main/java/com/patientpal/backend/post/controller/BoardController.java
@@ -11,9 +11,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
+import java.util.List;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+
 
 @RestController
 @RequestMapping("/api/v1/board")
@@ -57,7 +58,7 @@ public class BoardController {
     @ResponseStatus(HttpStatus.OK)
     public PostResponse update(@PathVariable("id") Long id, @RequestBody PostUpdateRequest updateRequest, @AuthenticationPrincipal User currentMember) {
         Member member = memberService.getUserByUsername(currentMember.getUsername());
-        Post post = postService.updatePost(id, updateRequest);
+        Post post = postService.updatePost(member, id, updateRequest);
         return new PostResponse(post);
     }
 
@@ -67,7 +68,7 @@ public class BoardController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable("id") Long id, @AuthenticationPrincipal User currentMember) {
         Member member = memberService.getUserByUsername(currentMember.getUsername());
-        postService.deletePost(id);
+        postService.deletePost(member, id);
     }
 
 }

--- a/src/main/java/com/patientpal/backend/post/controller/NoticeController.java
+++ b/src/main/java/com/patientpal/backend/post/controller/NoticeController.java
@@ -10,6 +10,7 @@ import com.patientpal.backend.post.libs.RoleType;
 import com.patientpal.backend.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
@@ -55,7 +56,7 @@ public class NoticeController {
     @ResponseStatus(HttpStatus.OK)
     public PostResponse update(@PathVariable("id") Long id, @RequestBody PostUpdateRequest updateRequest,@AuthenticationPrincipal User currentMember) {
         Member member = memberService.getUserByUsername(currentMember.getUsername());
-        Post post = postService.updatePost(id, updateRequest);
+        Post post = postService.updatePost(member, id, updateRequest);
         return new PostResponse(post);
     }
 
@@ -64,6 +65,6 @@ public class NoticeController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable("id") Long id, @AuthenticationPrincipal User currentMember) {
         Member member = memberService.getUserByUsername(currentMember.getUsername());
-        postService.deletePost(id);
+        postService.deletePost(member, id);
     }
 }

--- a/src/main/java/com/patientpal/backend/post/service/PostService.java
+++ b/src/main/java/com/patientpal/backend/post/service/PostService.java
@@ -50,16 +50,25 @@ public class PostService {
     }
 
     @Transactional
-    public Post updatePost(Long id, PostUpdateRequest updateRequest) {
+    public Post updatePost(Member member, Long id, PostUpdateRequest updateRequest) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND));
 
+        Member postMember = post.getMember();
+        if (!postMember.equals(member)) {
+            throw new EntityNotFoundException(ErrorCode.AUTHORIZATION_FAILED);
+        }
         post.update(updateRequest.getTitle(), updateRequest.getContent());
-
         return post;
     }
 
-    public void deletePost(Long id) {
+    public void deletePost(Member member, Long id) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND));
+        Member postMember = post.getMember();
+        if(!postMember.equals(member)) {
+            throw new EntityNotFoundException(ErrorCode.AUTHORIZATION_FAILED);
+        }
         postRepository.deleteById(id);
     }
 


### PR DESCRIPTION
<!-- 적절히 쪼개서 PR을 작성해주세요. 리뷰어가 한 번에 너무 많은 코드를 검토하면 읽기 어렵고 코드의 결함을 찾기 힘들어질 수 있어요! 😊 -->
## ✨ 작업 내용
- 공지사항, 자유게시판에 게시글 Update, Delete 함수 실행시 작성자와 현재 member 가 일치하는지 검사하도록 수정하였습니다
- 비교하여 일치하지 않으면 403을 반환합니다

<!-- 이 PR과 관련된 이슈 번호를 명시해주세요. 🔢 -->
<!-- 예를 들어, #123 형식으로 작성해주시고, 닫으려는 이슈가 있다면 "Fixes #123" 또는 "Closes #123" 형식으로 작성해주시면 PR이 머지될 때 해당 이슈가 자동으로 닫힙니다. -->
## 🔗 관련 이슈
- #106 