### PR TITLE
Feat: 게시글 반환시 Name, memberId 추가 

### DIFF
--- a/src/main/java/com/patientpal/backend/post/controller/BoardController.java
+++ b/src/main/java/com/patientpal/backend/post/controller/BoardController.java
@@ -11,9 +11,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
+import java.util.List;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+
 
 @RestController
 @RequestMapping("/api/v1/board")
@@ -57,7 +58,7 @@ public class BoardController {
     @ResponseStatus(HttpStatus.OK)
     public PostResponse update(@PathVariable("id") Long id, @RequestBody PostUpdateRequest updateRequest, @AuthenticationPrincipal User currentMember) {
         Member member = memberService.getUserByUsername(currentMember.getUsername());
-        Post post = postService.updatePost(id, updateRequest);
+        Post post = postService.updatePost(member, id, updateRequest);
         return new PostResponse(post);
     }
 
@@ -67,7 +68,7 @@ public class BoardController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable("id") Long id, @AuthenticationPrincipal User currentMember) {
         Member member = memberService.getUserByUsername(currentMember.getUsername());
-        postService.deletePost(id);
+        postService.deletePost(member, id);
     }
 
 }

--- a/src/main/java/com/patientpal/backend/post/controller/NoticeController.java
+++ b/src/main/java/com/patientpal/backend/post/controller/NoticeController.java
@@ -10,6 +10,7 @@ import com.patientpal.backend.post.libs.RoleType;
 import com.patientpal.backend.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
@@ -55,7 +56,7 @@ public class NoticeController {
     @ResponseStatus(HttpStatus.OK)
     public PostResponse update(@PathVariable("id") Long id, @RequestBody PostUpdateRequest updateRequest,@AuthenticationPrincipal User currentMember) {
         Member member = memberService.getUserByUsername(currentMember.getUsername());
-        Post post = postService.updatePost(id, updateRequest);
+        Post post = postService.updatePost(member, id, updateRequest);
         return new PostResponse(post);
     }
 
@@ -64,6 +65,6 @@ public class NoticeController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable("id") Long id, @AuthenticationPrincipal User currentMember) {
         Member member = memberService.getUserByUsername(currentMember.getUsername());
-        postService.deletePost(id);
+        postService.deletePost(member, id);
     }
 }

--- a/src/main/java/com/patientpal/backend/post/dto/PostCreateResponse.java
+++ b/src/main/java/com/patientpal/backend/post/dto/PostCreateResponse.java
@@ -12,6 +12,8 @@ import java.time.LocalDateTime;
 public class PostCreateResponse {
 
     private Long id;
+    private String name;
+    private Long memberId;
     private String title;
     private String content;
     private LocalDateTime createdDate;
@@ -19,6 +21,8 @@ public class PostCreateResponse {
 
     public PostCreateResponse(Post post) {
         this.id = post.getId();
+        this.name = post.getMember().getName();
+        this.memberId = post.getMember().getId();
         this.title = post.getTitle();
         this.content = post.getContent();
         this.createdDate = post.getCreatedDate();

--- a/src/main/java/com/patientpal/backend/post/dto/PostListResponse.java
+++ b/src/main/java/com/patientpal/backend/post/dto/PostListResponse.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostListResponse {
     private Long id;
+    private String name;
     private Long memberId;
     private String title;
     private LocalDateTime createdAt;
@@ -19,6 +20,7 @@ public class PostListResponse {
 
     public PostListResponse(Post post) {
         this.id = post.getId();
+        this.name = post.getMember().getName();
         this.memberId = post.getMember().getId();
         this.title = post.getTitle();
         this.createdAt = post.getCreatedDate();

--- a/src/main/java/com/patientpal/backend/post/dto/PostListResponse.java
+++ b/src/main/java/com/patientpal/backend/post/dto/PostListResponse.java
@@ -2,7 +2,6 @@ package com.patientpal.backend.post.dto;
 
 import com.patientpal.backend.post.domain.Post;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/patientpal/backend/post/dto/PostResponse.java
+++ b/src/main/java/com/patientpal/backend/post/dto/PostResponse.java
@@ -2,7 +2,6 @@ package com.patientpal.backend.post.dto;
 
 import com.patientpal.backend.post.domain.Post;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/patientpal/backend/post/dto/PostResponse.java
+++ b/src/main/java/com/patientpal/backend/post/dto/PostResponse.java
@@ -12,13 +12,18 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostResponse {
     private Long id;
+    private String name;
+    private Long memberId;
     private String title;
     private String content;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+
     public PostResponse(Post post) {
         this.id = post.getId();
+        this.name = post.getMember().getName();
+        this.memberId = post.getMember().getId();
         this.title = post.getTitle();
         this.content = post.getContent();
         this.createdAt = post.getCreatedDate();

--- a/src/main/java/com/patientpal/backend/post/repository/PostRepository.java
+++ b/src/main/java/com/patientpal/backend/post/repository/PostRepository.java
@@ -3,10 +3,18 @@ package com.patientpal.backend.post.repository;
 import com.patientpal.backend.post.domain.Post;
 import com.patientpal.backend.post.domain.PostType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findAllByPostType(PostType postType);
+
+    Optional<Post> findByIdAndMemberId(long postId, long memberId);
+
+    @Query("delete from Post p where p.id = :postId and p.member.id = :memberId")
+    int deleteByIdAndMemberId(@Param("postId") Long postId, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/patientpal/backend/post/repository/PostRepository.java
+++ b/src/main/java/com/patientpal/backend/post/repository/PostRepository.java
@@ -15,6 +15,4 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Optional<Post> findByIdAndMemberId(long postId, long memberId);
 
-    @Query("delete from Post p where p.id = :postId and p.member.id = :memberId")
-    int deleteByIdAndMemberId(@Param("postId") Long postId, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/patientpal/backend/post/repository/PostRepository.java
+++ b/src/main/java/com/patientpal/backend/post/repository/PostRepository.java
@@ -3,8 +3,6 @@ package com.patientpal.backend.post.repository;
 import com.patientpal.backend.post.domain.Post;
 import com.patientpal.backend.post.domain.PostType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/patientpal/backend/post/service/PostService.java
+++ b/src/main/java/com/patientpal/backend/post/service/PostService.java
@@ -57,10 +57,9 @@ public class PostService {
     }
 
     public void deletePost(Member member, Long id) {
-        int deletedPostCount = postRepository.deleteByIdAndMemberId(id, member.getId());
-        if(deletedPostCount == 0) {
-            throw new EntityNotFoundException(ErrorCode.POST_NOT_FOUND);
-        }
+        postRepository.findByIdAndMemberId(id, member.getId())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND));
+        postRepository.deleteById(id);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/patientpal/backend/post/service/PostService.java
+++ b/src/main/java/com/patientpal/backend/post/service/PostService.java
@@ -33,8 +33,7 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public Post getPost(Long id) {
-        return postRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND));
+        return findPost(id);
     }
 
     @Transactional
@@ -51,25 +50,17 @@ public class PostService {
 
     @Transactional
     public Post updatePost(Member member, Long id, PostUpdateRequest updateRequest) {
-        Post post = postRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND));
-
-        Member postMember = post.getMember();
-        if (!postMember.equals(member)) {
-            throw new EntityNotFoundException(ErrorCode.AUTHORIZATION_FAILED);
-        }
+        Post post = postRepository.findByIdAndMemberId(id, member.getId())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND);
         post.update(updateRequest.getTitle(), updateRequest.getContent());
         return post;
     }
 
     public void deletePost(Member member, Long id) {
-        Post post = postRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND));
-        Member postMember = post.getMember();
-        if(!postMember.equals(member)) {
-            throw new EntityNotFoundException(ErrorCode.AUTHORIZATION_FAILED);
+        int deletedPostCount = postRepository.deleteByIdAndMemberId(id, member.getId());
+        if(deletedPostCount == 0) {
+            throw new EntityNotFoundException(ErrorCode.POST_NOT_FOUND);
         }
-        postRepository.deleteById(id);
     }
 
     @Transactional(readOnly = true)
@@ -89,4 +80,8 @@ public class PostService {
         return postRepository.save(post);
     }
 
+    private Post findPost(Long id) {
+        return postRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/patientpal/backend/post/service/PostService.java
+++ b/src/main/java/com/patientpal/backend/post/service/PostService.java
@@ -51,7 +51,7 @@ public class PostService {
     @Transactional
     public Post updatePost(Member member, Long id, PostUpdateRequest updateRequest) {
         Post post = postRepository.findByIdAndMemberId(id, member.getId())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND);
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND));
         post.update(updateRequest.getTitle(), updateRequest.getContent());
         return post;
     }

--- a/src/main/java/com/patientpal/backend/post/service/PostService.java
+++ b/src/main/java/com/patientpal/backend/post/service/PostService.java
@@ -50,16 +50,25 @@ public class PostService {
     }
 
     @Transactional
-    public Post updatePost(Long id, PostUpdateRequest updateRequest) {
+    public Post updatePost(Member member, Long id, PostUpdateRequest updateRequest) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND));
 
+        Member postMember = post.getMember();
+        if (!postMember.equals(member)) {
+            throw new EntityNotFoundException(ErrorCode.AUTHORIZATION_FAILED);
+        }
         post.update(updateRequest.getTitle(), updateRequest.getContent());
-
         return post;
     }
 
-    public void deletePost(Long id) {
+    public void deletePost(Member member, Long id) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND));
+        Member postMember = post.getMember();
+        if(!postMember.equals(member)) {
+            throw new EntityNotFoundException(ErrorCode.AUTHORIZATION_FAILED);
+        }
         postRepository.deleteById(id);
     }
 


### PR DESCRIPTION
<!-- 적절히 쪼개서 PR을 작성해주세요. 리뷰어가 한 번에 너무 많은 코드를 검토하면 읽기 어렵고 코드의 결함을 찾기 힘들어질 수 있어요! 😊 -->
## ✨ 작업 내용
- post와 postList를 반환할 때 name, memberId 를 포함시켜 반환하도록 수정하였습니다.
- updatePost, createPost 에러를 POST_NOT_FOUND 에러로 통합하였습니다.

<!-- PR을 만들게 된 맥락(이를 수행하는 이유나 관련 링크 등)을 리뷰어가 알아야 한다면 함께 작성해주세요. 리뷰어가 히스토리를 완전히 알고 있다고 가정하지 않는 것이 좋아요. 😉 -->
<!-- 기술적인 접근법에 대한 토론, 디자인에 대한 비평 등 원하는 피드백의 방향과 내용을 명확히 알려주세요! -->
## 💬 리뷰어에게 남길 멘트
- 더 효율적인 방법이 있다면 의견 부탁드립니다.

<!-- 이 PR과 관련된 이슈 번호를 명시해주세요. 🔢 -->
<!-- 예를 들어, #123 형식으로 작성해주시고, 닫으려는 이슈가 있다면 "Fixes #123" 또는 "Closes #123" 형식으로 작성해주시면 PR이 머지될 때 해당 이슈가 자동으로 닫힙니다. -->
## 🔗 관련 이슈
- #110 
- #116 
