### PR TITLE
Feat: AWS CloudFront, Lambda@Edge를 도입하여 프로필 이미지 캐싱 기능 도입함

### DIFF
--- a/src/main/java/com/patientpal/backend/caregiver/controller/CaregiverControllerV1.java
+++ b/src/main/java/com/patientpal/backend/caregiver/controller/CaregiverControllerV1.java
@@ -49,7 +49,8 @@ public class CaregiverControllerV1 {
             @AuthenticationPrincipal User currentMember,
             @RequestBody @Valid CaregiverProfileCreateRequest caregiverProfileCreateRequest,
             @RequestParam(required = false) String profileImageUrl) {
-        CaregiverProfileDetailResponse caregiverProfileDetailResponse = caregiverService.saveCaregiverProfile(currentMember.getUsername(), caregiverProfileCreateRequest, presignedUrlService.getSavedUrl(profileImageUrl));
+        String savedCloudFrontUrl = presignedUrlService.getCloudFrontUrl("profiles", profileImageUrl);
+        CaregiverProfileDetailResponse caregiverProfileDetailResponse = caregiverService.saveCaregiverProfile(currentMember.getUsername(), caregiverProfileCreateRequest, savedCloudFrontUrl);
         return ResponseEntity.status(CREATED).body(caregiverProfileDetailResponse);
     }
 
@@ -78,7 +79,8 @@ public class CaregiverControllerV1 {
             @PathVariable Long memberId,
             @RequestBody @Valid CaregiverProfileUpdateRequest caregiverProfileUpdateRequest,
             @RequestParam(required = false) String profileImageUrl) {
-        caregiverService.updateCaregiverProfile(currentMember.getUsername(), memberId, caregiverProfileUpdateRequest, presignedUrlService.getSavedUrl(profileImageUrl));
+        String savedCloudFrontUrl = presignedUrlService.getCloudFrontUrl("profiles", profileImageUrl);
+        caregiverService.updateCaregiverProfile(currentMember.getUsername(), memberId, caregiverProfileUpdateRequest, savedCloudFrontUrl);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/patientpal/backend/image/service/PresignedUrlService.java
+++ b/src/main/java/com/patientpal/backend/image/service/PresignedUrlService.java
@@ -19,6 +19,9 @@ public class PresignedUrlService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
+    @Value("${cloudfront.domain}")
+    private String cloudFrontDomain;
+
     private final AmazonS3 amazonS3;
 
     public String getPresignedUrl(String prefix, String fileName) {
@@ -31,6 +34,15 @@ public class PresignedUrlService {
         URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
 
         return url.toString();
+    }
+
+    public String getCloudFrontUrl(String prefix, String wholeUrl) {
+        String urlWithoutParams = wholeUrl.split("\\?")[0];
+        String fileName = urlWithoutParams.substring(urlWithoutParams.lastIndexOf('/') + 1);
+        if (!prefix.isEmpty()) {
+            fileName = prefix + "/" + fileName;
+        }
+        return cloudFrontDomain + "/" + fileName;
     }
 
     private String onlyOneFileName(String filename) {
@@ -52,13 +64,5 @@ public class PresignedUrlService {
         expiration.setTime(expTimeMillis);
 
         return expiration;
-    }
-
-    public String getSavedUrl(String profileImageUrl) {
-        if (profileImageUrl == null) {
-            return null;
-        }
-        int queryIndex = profileImageUrl.indexOf('?');
-        return (queryIndex == -1) ? profileImageUrl : profileImageUrl.substring(0, queryIndex);
     }
 }

--- a/src/main/java/com/patientpal/backend/image/service/PresignedUrlService.java
+++ b/src/main/java/com/patientpal/backend/image/service/PresignedUrlService.java
@@ -42,7 +42,7 @@ public class PresignedUrlService {
         if (!prefix.isEmpty()) {
             fileName = prefix + "/" + fileName;
         }
-        return cloudFrontDomain + "/" + fileName;
+        return cloudFrontDomain + "/" + fileName + "?h=50";
     }
 
     private String onlyOneFileName(String filename) {

--- a/src/main/java/com/patientpal/backend/patient/controller/PatientControllerV1.java
+++ b/src/main/java/com/patientpal/backend/patient/controller/PatientControllerV1.java
@@ -49,7 +49,8 @@ public class PatientControllerV1 {
             @AuthenticationPrincipal User currentMember,
             @RequestBody @Valid PatientProfileCreateRequest patientProfileCreateRequest,
             @RequestParam(required = false) String profileImageUrl) {
-        PatientProfileDetailResponse patientProfileDetailResponse = patientService.savePatientProfile(currentMember.getUsername(), patientProfileCreateRequest, presignedUrlService.getSavedUrl(profileImageUrl));
+        String savedCloudFrontUrl = presignedUrlService.getCloudFrontUrl("profiles", profileImageUrl);
+        PatientProfileDetailResponse patientProfileDetailResponse = patientService.savePatientProfile(currentMember.getUsername(), patientProfileCreateRequest, savedCloudFrontUrl);
         return ResponseEntity.status(CREATED).body(patientProfileDetailResponse);
     }
 
@@ -78,7 +79,8 @@ public class PatientControllerV1 {
             @PathVariable Long memberId,
             @RequestBody @Valid PatientProfileUpdateRequest patientProfileUpdateRequest,
             @RequestParam(required = false) String profileImageUrl) {
-        patientService.updatePatientProfile(currentMember.getUsername(), memberId, patientProfileUpdateRequest, presignedUrlService.getSavedUrl(profileImageUrl));
+        String savedCloudFrontUrl = presignedUrlService.getCloudFrontUrl("profiles", profileImageUrl);
+        patientService.updatePatientProfile(currentMember.getUsername(), memberId, patientProfileUpdateRequest, savedCloudFrontUrl);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,9 @@ cloud:
       accessKey: ENC(tEeWEIeX8ZAdndGq/K7QW6yLiyry5Vo4rpRQBKI/YNdfMOgGtpRqf/aqwR+or0DAp+PXc6Q7RE54uYAt6wBN1A==)
       secretKey: ENC(Lo/mgU4/JW5OsWM9zyKZjH8XIz1AJyYyw2N281xL7iZnHMaSJ9vu/RwXsJfuQ2vzTKU3YYeUisMVh0sSEOD0Foz774tN/ZTjd1yXto572eU=)
 
+cloudfront:
+  domain: ENC(01drYBBlLccBHHJA8iC7qKld42M7VqefpmCv2r03PHocKpsBRSBFo9enqIJ98okaRaQwb5QRwpUFak42TEdBhVdEXntEwEAWld1EIMxwO8k=)
+
 ---
 spring:
   config:

--- a/src/test/java/com/patientpal/backend/fixtures/image/ImageFixture.java
+++ b/src/test/java/com/patientpal/backend/fixtures/image/ImageFixture.java
@@ -2,10 +2,10 @@ package com.patientpal.backend.fixtures.image;
 
 public class ImageFixture {
 
-    public static final String BUCKET = "test-bucket";
-    public static final String LOCATION = "us-east-1";
-    public static final String FILE_NAME = "test-file.txt";
-    public static final String PREFIX = "test-prefix";
-    public static final String USE_ONLY_ONE_FILE_NAME = "unique-test-file.txt";
-    public static final String PRESIGNED_URL = "https://" + BUCKET + ".s3." + LOCATION + ".amazonaws.com/" + PREFIX + "/" + USE_ONLY_ONE_FILE_NAME;
+    public static final String BUCKET = "patientpal-s3";
+    public static final String LOCATION = "ap-northeast-2";
+    public static final String FILE_NAME = "test-file.jpg";
+    public static final String PROFILE_PREFIX = "profiles";
+    public static final String PRESIGNED_URL = "https://" + BUCKET + ".s3." + LOCATION + ".amazonaws.com/" + PROFILE_PREFIX + "/" + FILE_NAME;
+    public static final String CLOUD_FRONT_URL = "https://cloudfront" + "/" + PROFILE_PREFIX + "/" + FILE_NAME;
 }


### PR DESCRIPTION
<!-- 적절히 쪼개서 PR을 작성해주세요. 리뷰어가 한 번에 너무 많은 코드를 검토하면 읽기 어렵고 코드의 결함을 찾기 힘들어질 수 있어요! 😊 -->
## ✨ 작업 내용
- 웹 CDN 서비스인 AWS CloudFront를 도입하여 캐싱 기능 활성화
- AWS Lambda@Edge를 이용하여 이미지 리사이징 진행.
- cloud front domain url 암호화 진행
- 관련 테스트 수정



<!-- 이 PR과 관련된 이슈 번호를 명시해주세요. 🔢 -->
<!-- 예를 들어, #123 형식으로 작성해주시고, 닫으려는 이슈가 있다면 "Fixes #123" 또는 "Closes #123" 형식으로 작성해주시면 PR이 머지될 때 해당 이슈가 자동으로 닫힙니다. -->
## 🔗 관련 이슈
- Closes #123 

<!-- 관련된 문서나 참고한 자료 링크를 추가해주세요! 🌐 -->
## 📚 레퍼런스
- https://docs.aws.amazon.com/cloudfront/
