### PR TITLE
Fix: 프로필 등록 시 이미지 null로  입력 되는 상황에 NPE 에러 처리

### DIFF
--- a/src/main/java/com/patientpal/backend/image/service/PresignedUrlService.java
+++ b/src/main/java/com/patientpal/backend/image/service/PresignedUrlService.java
@@ -37,6 +37,7 @@ public class PresignedUrlService {
     }
 
     public String getCloudFrontUrl(String prefix, String wholeUrl) {
+        if (wholeUrl == null) return null;
         String urlWithoutParams = wholeUrl.split("\\?")[0];
         String fileName = urlWithoutParams.substring(urlWithoutParams.lastIndexOf('/') + 1);
         if (!prefix.isEmpty()) {


### PR DESCRIPTION
<!-- 적절히 쪼개서 PR을 작성해주세요. 리뷰어가 한 번에 너무 많은 코드를 검토하면 읽기 어렵고 코드의 결함을 찾기 힘들어질 수 있어요! 😊 -->
## ✨ 작업 내용
- 프로필 등록 시 image를 선택 안했을시, 이미지 값 null로 들어가게 예외 처리
