### PR TITLE
Feat: 소셜 로그인 기능 부분 및 로그아웃 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     compileOnly 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/patientpal/backend/auth/controller/AuthenticationApiV1Controller.java
+++ b/src/main/java/com/patientpal/backend/auth/controller/AuthenticationApiV1Controller.java
@@ -6,8 +6,17 @@ import com.patientpal.backend.auth.dto.SignUpRequest;
 import com.patientpal.backend.auth.dto.TokenDto;
 import com.patientpal.backend.auth.service.JwtLoginService;
 import com.patientpal.backend.auth.service.JwtTokenService;
+import com.patientpal.backend.common.exception.BusinessException;
+import com.patientpal.backend.common.exception.EntityNotFoundException;
+import com.patientpal.backend.common.exception.ErrorCode;
+import com.patientpal.backend.member.domain.Member;
+import com.patientpal.backend.member.domain.Role;
 import com.patientpal.backend.member.service.MemberService;
 import com.patientpal.backend.security.jwt.JwtTokenProvider;
+import com.patientpal.backend.security.oauth.CustomOauth2UserPrincipal;
+import com.patientpal.backend.security.oauth.dto.Oauth2SignUpRequest;
+import com.patientpal.backend.security.oauth.dto.Oauth2SignUpResponse;
+import com.patientpal.backend.security.oauth.userinfo.CustomOauth2UserInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -15,16 +24,29 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.patientpal.backend.common.exception.ErrorCode.INVALID_USERNAME;
+import static com.patientpal.backend.common.exception.ErrorCode.MEMBER_NOT_EXIST;
 
 @Tag(name = "인증", description = "인증 API")
 @RestController
@@ -65,6 +87,48 @@ public class AuthenticationApiV1Controller {
         return ResponseEntity.created(URI.create("/api/v1/members/" + memberService.save(request))).build();
     }
 
+    @GetMapping("/oauth2/register")
+    @Operation(summary = "소셜 회원가입 정보 가져오기", description = "소셜 로그인 후 회원가입 페이지에서 필요한 정보를 가져온다.")
+    @ApiResponse(responseCode = "200", description = "소셜 회원가입 정보 가져오기 성공",
+            content = @Content(schema = @Schema(implementation = Oauth2SignUpResponse.class)))
+    public ResponseEntity<Oauth2SignUpResponse> getOauth2UserInfo(HttpSession session) {
+        Oauth2SignUpResponse response = createOauth2SignUpResponse(session);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/oauth2/register")
+    @Operation(summary = "소셜 회원가입", description = "소셜 로그인 후 추가 정보를 입력받아 회원가입을 한다.")
+    @ApiResponse(responseCode = "201", description = "회원가입 성공",
+            content = @Content(schema = @Schema(implementation = Oauth2SignUpResponse.class)))
+    public ResponseEntity<Oauth2SignUpResponse> processOauth2Signup(@Valid @RequestBody Oauth2SignUpRequest signupForm,
+                                                                    HttpSession session) {
+        String username = getUsername(signupForm, session);
+
+        memberService.saveSocialUser(signupForm);
+
+        Member member = getMember(username);
+        String token = generateToken(member, signupForm.getProvider(), signupForm.getEmail(), signupForm.getName());
+
+        session.setAttribute("token", token);
+
+        Oauth2SignUpResponse response = Oauth2SignUpResponse.fromMember(member, signupForm.getEmail(), signupForm.getName(), signupForm.getRole().name(), signupForm.getProvider(), token);
+
+        return ResponseEntity.created(URI.create("/api/v1/members/" + member.getId())).body(response);
+    }
+
+    @GetMapping("/logout")
+    @Operation(summary = "로그아웃", description = "사용자를 로그아웃한다.")
+    public void logout(HttpServletRequest req, HttpServletResponse resp,
+                         @CookieValue("refresh_token") String refreshToken) {
+        if (refreshToken != null) {
+            jwtTokenProvider.invalidateToken(refreshToken);
+        }
+        new SecurityContextLogoutHandler()
+                .logout(req, resp, SecurityContextHolder.getContext().getAuthentication());
+        resp.setStatus(HttpServletResponse.SC_FOUND);
+        resp.setHeader("Location", "/login");
+    }
+
     private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
         Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
         refreshTokenCookie.setHttpOnly(true);
@@ -74,4 +138,50 @@ public class AuthenticationApiV1Controller {
         refreshTokenCookie.setMaxAge((int) (jwtTokenProvider.refreshTokenExpirationTime / 1000));
         response.addCookie(refreshTokenCookie);
     }
+
+    private Oauth2SignUpResponse createOauth2SignUpResponse(HttpSession session) {
+        String email = (String) session.getAttribute("email");
+        String name = (String) session.getAttribute("name");
+        Role role = (Role) session.getAttribute("role");
+        String provider = (String) session.getAttribute("provider");
+        String username = (String) session.getAttribute("username");
+        String token = (String) session.getAttribute("token");
+
+        if (username == null || username.isEmpty()) {
+            throw new BusinessException(INVALID_USERNAME, "Username is not set in session");
+        }
+
+        Member member = memberService.getUserByUsername(username);
+
+        if (member == null) {
+            throw new EntityNotFoundException(MEMBER_NOT_EXIST, "Member not found with username: " + username);
+        }
+
+        return Oauth2SignUpResponse.fromMember(member, email, name, role.name(), provider, token);
+    }
+
+    private String generateToken(Member member, String provider, String email, String name) {
+        CustomOauth2UserInfo userInfo = CustomOauth2UserInfo.of(provider, Map.of("email", email, "name", name));
+        String password = member.getPassword() != null ? member.getPassword() : "DUMMY_PASSWORD";
+        CustomOauth2UserPrincipal principal = new CustomOauth2UserPrincipal(member.getUsername(), password, Collections.singletonList(new SimpleGrantedAuthority(member.getRole().name())));
+        principal.setUserInfo(userInfo);
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+        return jwtTokenProvider.createAccessToken(authentication);
+    }
+
+    private String getUsername(Oauth2SignUpRequest signupForm, HttpSession session) {
+        String username = (String) session.getAttribute("username");
+        signupForm.setUsername(username);
+        return username;
+    }
+
+    private Member getMember(String username) {
+        Member member = memberService.getUserByUsername(username);
+        if (member == null) {
+            throw new BusinessException(ErrorCode.MEMBER_NOT_EXIST, "Member not found with username: " + username);
+        }
+        return member;
+    }
 }
+

--- a/src/main/java/com/patientpal/backend/common/advice/RestApiExceptionHandler.java
+++ b/src/main/java/com/patientpal/backend/common/advice/RestApiExceptionHandler.java
@@ -7,9 +7,11 @@ import com.patientpal.backend.webhook.service.DiscordWebhookService;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -58,4 +60,12 @@ public class RestApiExceptionHandler {
         log.error(e.getMessage(), e);
         return new ResponseEntity<>(response, response.getStatus());
     }
+
+    @ExceptionHandler(MissingRequestCookieException.class)
+    protected ResponseEntity<ErrorResponse> handleMissingRequestCookieException(MissingRequestCookieException e) {
+        var response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
+        log.debug("Required cookie is missing: {}", e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
 }

--- a/src/main/java/com/patientpal/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/patientpal/backend/common/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AU_001", "이메일 또는 비밀번호가 일치하지 않습니다."),
     UNSUPPORTED_OAUTH2_PROVIDER(HttpStatus.BAD_REQUEST, "AU_002", "지원하지 않는 OAuth2 프로바이더입니다."),
     UNSELECTED_ROLE(HttpStatus.BAD_REQUEST, "AU_003", "역할이 선택되지 않았습니다."),
+    INVALID_USERNAME(HttpStatus.BAD_REQUEST, "AU_004", "유효하지 않은 사용자 이름입니다."),
 
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "V_001", "유효하지 않은 토큰입니다."),
     INVALID_RESIDENT_REGISTRATION_NUMBER(HttpStatus.NON_AUTHORITATIVE_INFORMATION, "V_002", "유효하지 않은 주민등록번호입니다."),

--- a/src/main/java/com/patientpal/backend/config/OAuth2ClientConfig.java
+++ b/src/main/java/com/patientpal/backend/config/OAuth2ClientConfig.java
@@ -1,0 +1,90 @@
+package com.patientpal.backend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
+
+@Configuration
+public class OAuth2ClientConfig {
+
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String googleClientId;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    private String googleClientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String kakaoClientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
+    private String naverClientId;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+    private String naverClientSecret;
+
+    @Bean
+    public ClientRegistrationRepository clientRegistrationRepository() {
+        return new InMemoryClientRegistrationRepository(
+                googleClientRegistration(),
+                kakaoClientRegistration(),
+                naverClientRegistration()
+        );
+    }
+
+    private ClientRegistration googleClientRegistration() {
+        return ClientRegistration.withRegistrationId("google")
+                .clientId(googleClientId)
+                .clientSecret(googleClientSecret)
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                .scope("openid", "profile", "email")
+                .authorizationUri("https://accounts.google.com/o/oauth2/auth")
+                .tokenUri("https://oauth2.googleapis.com/token")
+                .userInfoUri("https://www.googleapis.com/oauth2/v3/userinfo")
+                .userNameAttributeName(IdTokenClaimNames.SUB)
+                .clientName("Google")
+                .build();
+    }
+
+    private ClientRegistration kakaoClientRegistration() {
+        return ClientRegistration.withRegistrationId("kakao")
+                .clientId(kakaoClientId)
+                .clientSecret(kakaoClientSecret)
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                .scope("profile")
+                .authorizationUri("https://kauth.kakao.com/oauth/authorize")
+                .tokenUri("https://kauth.kakao.com/oauth/token")
+                .userInfoUri("https://kapi.kakao.com/v2/user/me")
+                .userNameAttributeName("id")
+                .clientName("Kakao")
+                .build();
+    }
+
+    private ClientRegistration naverClientRegistration() {
+        return ClientRegistration.withRegistrationId("naver")
+                .clientId(naverClientId)
+                .clientSecret(naverClientSecret)
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                .scope("profile")
+                .authorizationUri("https://nid.naver.com/oauth2.0/authorize")
+                .tokenUri("https://nid.naver.com/oauth2.0/token")
+                .userInfoUri("https://openapi.naver.com/v1/nid/me")
+                .userNameAttributeName("response.id")
+                .clientName("Naver")
+                .build();
+    }
+}

--- a/src/main/java/com/patientpal/backend/config/RedisConfig.java
+++ b/src/main/java/com/patientpal/backend/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package com.patientpal.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+import org.springframework.session.web.http.CookieHttpSessionIdResolver;
+import org.springframework.session.web.http.HttpSessionIdResolver;
+
+@Configuration
+@EnableRedisHttpSession
+public class RedisConfig {
+
+    @Bean
+    public HttpSessionIdResolver httpSessionIdResolver() {
+        return new CookieHttpSessionIdResolver();
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/com/patientpal/backend/member/repository/MemberRepository.java
+++ b/src/main/java/com/patientpal/backend/member/repository/MemberRepository.java
@@ -17,4 +17,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     }
 
     void deleteByUsername(String username);
+
+    boolean existsByUsername(String username);
 }

--- a/src/main/java/com/patientpal/backend/security/oauth/CustomOauth2UserPrincipal.java
+++ b/src/main/java/com/patientpal/backend/security/oauth/CustomOauth2UserPrincipal.java
@@ -2,14 +2,19 @@ package com.patientpal.backend.security.oauth;
 
 import com.patientpal.backend.member.domain.Member;
 import com.patientpal.backend.security.oauth.userinfo.CustomOauth2UserInfo;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+@Getter
 public class CustomOauth2UserPrincipal extends User implements OAuth2User {
     private transient CustomOauth2UserInfo userInfo;
+    private String registrationId;
 
     public CustomOauth2UserPrincipal(Member member) {
         super(member.getUsername(), member.getPassword(),
@@ -29,5 +34,12 @@ public class CustomOauth2UserPrincipal extends User implements OAuth2User {
     @Override
     public String getName() {
         return userInfo.getName();
+    }
+
+    public CustomOauth2UserPrincipal(String username, String password, Collection<? extends GrantedAuthority> authorities) {
+        super(username, password, authorities);
+    }
+    public void setUserInfo(CustomOauth2UserInfo userInfo) {
+        this.userInfo = userInfo;
     }
 }

--- a/src/main/java/com/patientpal/backend/security/oauth/dto/Oauth2SignUpRequest.java
+++ b/src/main/java/com/patientpal/backend/security/oauth/dto/Oauth2SignUpRequest.java
@@ -1,0 +1,32 @@
+package com.patientpal.backend.security.oauth.dto;
+
+import com.patientpal.backend.member.domain.Role;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class Oauth2SignUpRequest {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    private String password;
+
+    @NotNull
+    private Role role;
+
+    @NotBlank
+    private String provider;
+
+    @NotBlank
+    private String username;
+}

--- a/src/main/java/com/patientpal/backend/security/oauth/dto/Oauth2SignUpResponse.java
+++ b/src/main/java/com/patientpal/backend/security/oauth/dto/Oauth2SignUpResponse.java
@@ -1,0 +1,48 @@
+package com.patientpal.backend.security.oauth.dto;
+
+import com.patientpal.backend.member.domain.Address;
+import com.patientpal.backend.member.domain.Gender;
+import com.patientpal.backend.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Oauth2SignUpResponse {
+    private String email;
+    private String name;
+    private String role;
+    private String provider;
+    private String token;
+    private Long memberId;
+    private Boolean isProfilePublic;
+    private Boolean isCompleteProfile;
+    private String profileImageUrl;
+    private String contact;
+    private Address address;
+    private Gender gender;
+    private int age;
+
+
+    public static Oauth2SignUpResponse fromMember(Member member, String email, String name, String role, String provider, String token) {
+        return Oauth2SignUpResponse.builder()
+                .email(email)
+                .name(name)
+                .role(role)
+                .provider(provider)
+                .token(token)
+                .memberId(member.getId())
+                .isProfilePublic(member.getIsProfilePublic())
+                .isCompleteProfile(member.getIsCompleteProfile())
+                .profileImageUrl(member.getProfileImageUrl())
+                .contact(member.getContact())
+                .address(member.getAddress())
+                .gender(member.getGender())
+                .age(member.getAge())
+                .build();
+    }
+}

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -1,0 +1,42 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope: profile, email
+            redirect-uri: "{baseUrl}/login/oauth2/code/google"
+            authorization-grant-type: authorization_code
+            client-name: Google
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            scope: profile_nickname, account_email
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            authorization-grant-type: authorization_code
+            client-name: Kakao
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            scope: name, email
+            redirect-uri: "{baseUrl}/login/oauth2/code/naver"
+            authorization-grant-type: authorization_code
+            client-name: Naver
+        provider:
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            user-name-attribute: name
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   profiles:
     active: local # [local, prod]
+    include: oauth2
 
   application:
     name: backend
@@ -74,11 +75,19 @@ spring:
       enabled: true
       path: /h2-console
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+    session:
+      store-type: redis
+
 ---
 spring:
   config:
     activate:
       on-profile: "prod"
+      include: oauth2
 
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver

--- a/src/test/java/com/patientpal/backend/auth/controller/AuthenticationApiV1ControllerTest.java
+++ b/src/test/java/com/patientpal/backend/auth/controller/AuthenticationApiV1ControllerTest.java
@@ -1,30 +1,51 @@
 package com.patientpal.backend.auth.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.patientpal.backend.auth.dto.SignInRequest;
 import com.patientpal.backend.auth.dto.TokenDto;
 import com.patientpal.backend.auth.service.JwtLoginService;
 import com.patientpal.backend.auth.service.JwtTokenService;
 import com.patientpal.backend.common.exception.AuthenticationException;
+import com.patientpal.backend.common.exception.BusinessException;
 import com.patientpal.backend.common.exception.EntityNotFoundException;
 import com.patientpal.backend.common.exception.ErrorCode;
 import com.patientpal.backend.fixtures.auth.SignInRequestFixture;
 import com.patientpal.backend.fixtures.auth.TokenDtoFixture;
+import com.patientpal.backend.member.domain.Member;
+import com.patientpal.backend.member.domain.Role;
+import com.patientpal.backend.member.service.MemberService;
+import com.patientpal.backend.security.jwt.JwtTokenProvider;
+import com.patientpal.backend.security.oauth.dto.Oauth2SignUpRequest;
 import com.patientpal.backend.test.CommonControllerSliceTest;
 import com.patientpal.backend.test.annotation.AutoKoreanDisplayName;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 @AutoKoreanDisplayName
 @SuppressWarnings("NonAsciiCharacters")
@@ -35,6 +56,25 @@ class AuthenticationApiV1ControllerTest extends CommonControllerSliceTest {
 
     @Autowired
     private JwtTokenService tokenService;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+        objectMapper = new ObjectMapper();
+    }
 
     @Nested
     class 사용자가_로그인_시에 {
@@ -49,8 +89,8 @@ class AuthenticationApiV1ControllerTest extends CommonControllerSliceTest {
 
             // when & then
             mockMvc.perform(post("/api/v1/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.access_token").value(TokenDtoFixture.VALID_ACCESS_TOKEN))
                     .andExpect(cookie().value("refresh_token", TokenDtoFixture.VALID_REFRESH_TOKEN));
@@ -61,12 +101,13 @@ class AuthenticationApiV1ControllerTest extends CommonControllerSliceTest {
             // given
             SignInRequest request = SignInRequestFixture.createInvalidPasswordSignInRequest();
 
-            doThrow(new EntityNotFoundException(ErrorCode.MEMBER_NOT_EXIST)).when(loginService).authenticateUser(any(SignInRequest.class));
+            doThrow(new EntityNotFoundException(ErrorCode.MEMBER_NOT_EXIST)).when(loginService)
+                    .authenticateUser(any(SignInRequest.class));
 
             // when & then
             mockMvc.perform(post("/api/v1/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.access_token").doesNotExist())
                     .andExpect(cookie().doesNotExist("refresh_token"));
@@ -86,8 +127,8 @@ class AuthenticationApiV1ControllerTest extends CommonControllerSliceTest {
 
             // when & then
             mockMvc.perform(post("/api/v1/auth/refresh")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new Cookie("refresh_token", TokenDtoFixture.VALID_REFRESH_TOKEN)))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .cookie(new Cookie("refresh_token", TokenDtoFixture.VALID_REFRESH_TOKEN)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.access_token").value(newTokens.accessToken()))
                     .andExpect(cookie().value("refresh_token", newTokens.refreshToken()));
@@ -97,12 +138,13 @@ class AuthenticationApiV1ControllerTest extends CommonControllerSliceTest {
         @WithMockUser
         void 유효하지_않으면_예외가_발생한다() throws Exception {
             // given
-            doThrow(new AuthenticationException(ErrorCode.INVALID_TOKEN)).when(tokenService).refreshJwtTokens(TokenDtoFixture.INVALID_REFRESH_TOKEN);
+            doThrow(new AuthenticationException(ErrorCode.INVALID_TOKEN)).when(tokenService)
+                    .refreshJwtTokens(TokenDtoFixture.INVALID_REFRESH_TOKEN);
 
             // when & then
             mockMvc.perform(post("/api/v1/auth/refresh")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new Cookie("refresh_token", TokenDtoFixture.INVALID_REFRESH_TOKEN)))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .cookie(new Cookie("refresh_token", TokenDtoFixture.INVALID_REFRESH_TOKEN)))
                     .andExpect(status().isUnauthorized())
                     .andExpect(jsonPath("$.access_token").doesNotExist());
         }
@@ -112,4 +154,178 @@ class AuthenticationApiV1ControllerTest extends CommonControllerSliceTest {
     class 사용자가_회원가입_시에 {
         // TODO: 회원가입 양식이 제대로 정해지면 테스트를 새로 작성해야 함
     }
+
+    @Nested
+    class 사용자가_소셜_회원가입_정보_가져올_때 {
+        @Test
+        @WithMockUser
+        void 성공한다() throws Exception {
+            // given
+            MockHttpSession session = new MockHttpSession();
+            session.setAttribute("email", "test@example.com");
+            session.setAttribute("name", "Test User");
+            session.setAttribute("role", Role.USER);
+            session.setAttribute("provider", "google");
+            session.setAttribute("username", "testuser");
+
+            Member member = Member.builder()
+                    .id(1L)
+                    .username("testuser")
+                    .isProfilePublic(true)
+                    .isCompleteProfile(true)
+                    .build();
+
+            when(memberService.getUserByUsername("testuser")).thenReturn(member);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/auth/oauth2/register")
+                            .session(session))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.email").value("test@example.com"))
+                    .andExpect(jsonPath("$.name").value("Test User"))
+                    .andExpect(jsonPath("$.role").value("USER"))
+                    .andExpect(jsonPath("$.provider").value("google"))
+                    .andExpect(jsonPath("$.memberId").value(1L));
+        }
+
+        @Test
+        @WithMockUser
+        void 사용자가_존재하지_않으면_예외가_발생한다() throws Exception {
+            // given
+            MockHttpSession session = new MockHttpSession();
+            session.setAttribute("username", "nonexistentuser");
+
+            when(memberService.getUserByUsername("nonexistentuser"))
+                    .thenThrow(new EntityNotFoundException(ErrorCode.MEMBER_NOT_EXIST, "Member not found with username: nonexistentuser"));
+
+            // when & then
+            mockMvc.perform(get("/api/v1/auth/oauth2/register")
+                            .session(session))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(result -> {
+                        Throwable resolvedException = result.getResolvedException();
+                        assert resolvedException instanceof EntityNotFoundException;
+                        assert ((EntityNotFoundException) resolvedException).getErrorCode().equals(ErrorCode.MEMBER_NOT_EXIST);
+                    });
+        }
+
+        @Test
+        @WithMockUser
+        void 유효하지_않은_사용자명_예외가_발생한다() throws Exception {
+            // given
+            MockHttpSession session = new MockHttpSession();
+            session.setAttribute("username", "");
+
+            // when & then
+            mockMvc.perform(get("/api/v1/auth/oauth2/register")
+                            .session(session))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(result -> {
+                        Throwable resolvedException = result.getResolvedException();
+                        assert resolvedException instanceof BusinessException;
+                        assert ((BusinessException) resolvedException).getErrorCode().equals(ErrorCode.INVALID_USERNAME);
+                    });
+        }
+    }
+
+    @Nested
+    class 소셜_회원가입 {
+
+        private Oauth2SignUpRequest validSignUpRequest;
+        private MockHttpSession session;
+
+        @BeforeEach
+        void setUp() {
+            validSignUpRequest = new Oauth2SignUpRequest(
+                    "test@example.com",
+                    "Test User",
+                    "password",
+                    Role.USER,
+                    "google",
+                    "testuser"
+            );
+
+            session = new MockHttpSession();
+            session.setAttribute("username", "testuser");
+        }
+
+        @Test
+        void 성공한다() throws Exception {
+            // Mock memberService.getUserByUsername to return a valid member
+            Member member = Member.builder()
+                    .id(1L)
+                    .username("testuser")
+                    .isProfilePublic(true)
+                    .isCompleteProfile(true)
+                    .role(Role.USER) // role 설정
+                    .build();
+
+            when(memberService.getUserByUsername("testuser")).thenReturn(member);
+
+            // Mock jwtTokenProvider.createAccessToken to return a valid token
+            String validToken = "validToken";
+            when(jwtTokenProvider.createAccessToken(any())).thenReturn(validToken);
+
+            // Perform the request and verify the result
+            mockMvc.perform(post("/api/v1/auth/oauth2/register")
+                            .session(session)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validSignUpRequest)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.email").value("test@example.com"))
+                    .andExpect(jsonPath("$.name").value("Test User"))
+                    .andExpect(jsonPath("$.role").value("USER"))
+                    .andExpect(jsonPath("$.provider").value("google"))
+                    .andExpect(jsonPath("$.memberId").value(1L));
+        }
+
+
+        @Test
+        void 회원이_존재하지_않으면_예외가_발생한다() throws Exception {
+            // Mock memberService.getUserByUsername to return null
+            when(memberService.getUserByUsername(anyString())).thenReturn(null);
+
+            mockMvc.perform(post("/api/v1/auth/oauth2/register")
+                            .session(session)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validSignUpRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(result -> {
+                        Throwable resolvedException = result.getResolvedException();
+                        assert resolvedException instanceof BusinessException;
+                        assert ((BusinessException) resolvedException).getErrorCode()
+                                .equals(ErrorCode.MEMBER_NOT_EXIST);
+                    });
+        }
+    }
+
+    @Nested
+    class 로그아웃 {
+
+        @Test
+        @WithMockUser
+        void 성공한다() throws Exception {
+            // given
+            String validRefreshToken = "validRefreshToken";
+            Cookie refreshTokenCookie = new Cookie("refresh_token", validRefreshToken);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/auth/logout")
+                            .cookie(refreshTokenCookie))
+                    .andExpect(status().isFound()); // 302
+                    // .andExpect(redirectedUrl("/")); // 아직 해당 페이지가 없으므로 주석 처리함
+
+            // Verify if the token is invalidated
+            verify(jwtTokenProvider, times(1)).invalidateToken(validRefreshToken);
+        }
+
+        @Test
+        @WithMockUser
+        void 리프레시_토큰이_없으면_예외가_발생한다() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/v1/auth/logout"))
+                    .andExpect(status().isBadRequest());
+        }
+    }
 }
+


### PR DESCRIPTION
## ✨ 작업 내용

1. application-oauth2.yml 에 구글, 카카오, 네이버 api 등록 (client-id 와 client-secret는 환경 변수로 등록해야함)
2. 소셜 계정 정보 가져오기
3. 소셜 계정로그인 과정에 회원일 경우 바로 로그인, 아닌 경우 회원가입
5. 회원가입시 중복 닉네임이 있을경우 뒤에 임의의 숫자 붙임
5. 로그아웃시 토큰 무효화를 위해 redis 도입
6. refresh token의 유효기간을 redis에 저장하여 유효기간이 지나면 삭제되어, 토큰 무효화 구현
7. AuthenticationApiV1ControllerTest에 소셜 회원가입, 로그아웃 테스트 구현

<!-- 관련된 문서나 참고한 자료 링크를 추가해주세요! 🌐 -->
## 📚 레퍼런스
- 
