### PR TITLE
Fix: add check-username validate

### DIFF
--- a/src/main/java/com/patientpal/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/patientpal/backend/common/exception/ErrorCode.java
@@ -11,7 +11,7 @@ public enum ErrorCode {
 
     AUTHORIZATION_FAILED(HttpStatus.FORBIDDEN, "AR_001", "권한이 없습니다."),
 
-    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AU_001", "이메일 또는 비밀번호가 일치하지 않습니다."),
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AU_001", "아이디 또는 비밀번호가 일치하지 않습니다."),
     UNSUPPORTED_OAUTH2_PROVIDER(HttpStatus.BAD_REQUEST, "AU_002", "지원하지 않는 OAuth2 프로바이더입니다."),
     UNSELECTED_ROLE(HttpStatus.BAD_REQUEST, "AU_003", "역할이 선택되지 않았습니다."),
     INVALID_USERNAME(HttpStatus.BAD_REQUEST, "AU_004", "유효하지 않은 사용자 이름입니다."),
@@ -20,7 +20,7 @@ public enum ErrorCode {
     INVALID_RESIDENT_REGISTRATION_NUMBER(HttpStatus.NON_AUTHORITATIVE_INFORMATION, "V_002", "유효하지 않은 주민등록번호입니다."),
 
     MEMBER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "M_001", "이미 가입된 계정이 존재합니다."),
-    MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST, "M_002", "해당 멤버는 존재하지 않습니다."),
+    MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST, "M_002", "해당 계정은 존재하지 않습니다."),
     NOT_COMPLETE_PROFILE(HttpStatus.NOT_FOUND, "M_003", "프로필이 등록되어 있지 않습니다."),
     CAN_NOT_DELETE_PROFILE(HttpStatus.BAD_REQUEST, "M_004", "진행 중인 매칭이 있어 프로필을 삭제할 수 없습니다."),
 

--- a/src/main/java/com/patientpal/backend/member/controller/MemberController.java
+++ b/src/main/java/com/patientpal/backend/member/controller/MemberController.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,5 +27,16 @@ public class MemberController {
     public ResponseEntity<MemberCompleteProfileResponse> getIsCompleteProfile(@AuthenticationPrincipal User user) {
         Member member = memberService.getUserByUsername(user.getUsername());
         return ResponseEntity.status(HttpStatus.OK).body(MemberCompleteProfileResponse.of(member.getId(), member.getName(), member.getIsCompleteProfile()));
+    }
+
+    @GetMapping("/api/v1/member/isProfilePublic")
+    public ResponseEntity<Boolean> getIsProfilePublic(@AuthenticationPrincipal User user) {
+        Member member = memberService.getUserByUsername(user.getUsername());
+        return ResponseEntity.status(HttpStatus.OK).body(member.getIsProfilePublic());
+    }
+
+    @GetMapping("/api/v1/member/check-username")
+    public ResponseEntity<Boolean> checkUsernameAvailability(@RequestParam String username) {
+        return ResponseEntity.ok(memberService.existsByUsername(username));
     }
 }

--- a/src/main/java/com/patientpal/backend/member/repository/MemberRepository.java
+++ b/src/main/java/com/patientpal/backend/member/repository/MemberRepository.java
@@ -21,7 +21,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     void deleteByUsername(String username);
 
-    boolean existsByUsername(String username);
+    Boolean existsByUsername(String username);
 
     @Query("select m.username from Member m where m.username like :username%")
     List<String> findUsernameStartingWith(@Param("username") String username);

--- a/src/main/java/com/patientpal/backend/member/service/MemberService.java
+++ b/src/main/java/com/patientpal/backend/member/service/MemberService.java
@@ -66,6 +66,7 @@ public class MemberService {
                         .role(Role.ADMIN)
                         .provider(Provider.LOCAL)
                         .build();
+                member.encodePassword(passwordEncoder);
                 return memberRepository.save(member).getId();
             }
 
@@ -129,7 +130,7 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public boolean existsByUsername(String username) {
+    public Boolean existsByUsername(String username) {
         return memberRepository.existsByUsername(username);
     }
 


### PR DESCRIPTION
<!-- 적절히 쪼개서 PR을 작성해주세요. 리뷰어가 한 번에 너무 많은 코드를 검토하면 읽기 어렵고 코드의 결함을 찾기 힘들어질 수 있어요! 😊 -->
## ✨ 작업 내용
- 에러 코드 수정
- 가입시 username 중복 체크
- admin 가입 시 passwordencoder 설정
- isProfilePublic 반환 api 
