### PR TITLE
[Refactoring] 소셜로그인 인가코드 및 엑세스 요청 코드 변경

### DIFF
--- a/src/main/java/com/patientpal/backend/auth/controller/OAuth2LoginController.java
+++ b/src/main/java/com/patientpal/backend/auth/controller/OAuth2LoginController.java
@@ -8,8 +8,8 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -18,12 +18,10 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
-
 import com.patientpal.backend.auth.dto.TokenDto;
 import com.patientpal.backend.auth.service.JwtLoginService;
 import com.patientpal.backend.auth.service.SocialDataService;
@@ -38,7 +36,6 @@ import com.patientpal.backend.security.oauth.CustomOauth2UserPrincipal;
 import com.patientpal.backend.security.oauth.dto.Oauth2SignUpRequest;
 import com.patientpal.backend.security.oauth.dto.Oauth2SignUpResponse;
 import com.patientpal.backend.security.oauth.userinfo.CustomOauth2UserInfo;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -46,7 +43,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "인증", description = "인증 API")
@@ -155,19 +151,23 @@ public class OAuth2LoginController {
     @Operation(summary = "소셜 회원가입 또는 로그인", description = "소셜 로그인 후 회원가입 또는 로그인 절차를 수행한다.")
     @ApiResponse(responseCode = "200", description = "회원가입 또는 로그인 성공",
             content = @Content(schema = @Schema(implementation = Oauth2SignUpResponse.class)))
-    public ResponseEntity<Oauth2SignUpResponse> processOauth2Signup(@Valid @RequestBody Oauth2SignUpRequest signupForm,
-                                                                    HttpSession session) {
-        String username = getUsername(signupForm, session);
-        Member member = memberService.getUserByUsername(username);
+    public ResponseEntity<Oauth2SignUpResponse> processOauth2Signup(HttpSession session) {
+        String username = (String) session.getAttribute("username");
+        String email = (String) session.getAttribute("email");
+        String name = (String) session.getAttribute("name");
+        String provider = (String) session.getAttribute("provider");
 
-        if(member != null) {
-            return createLoginResponse(signupForm, session, member);
+        Optional<Member> optionalMember = memberService.findOptionalByUsername(username);
+        if(optionalMember.isPresent()) {
+            Member member = optionalMember.get();
+            return createLoginResponse(session, member);
         }
 
+        Oauth2SignUpRequest signupForm = new Oauth2SignUpRequest(email, name, provider, username);
         Long newMemberId = memberService.saveSocialUser(signupForm);
         Member newMember = memberService.getUserById(newMemberId);
 
-        return createSignupResponse(signupForm, session, newMember);
+        return createSignupResponse(signupForm,session, newMember);
     }
 
     private ResponseEntity<Oauth2SignUpResponse> createSignupResponse(Oauth2SignUpRequest signupForm,
@@ -182,15 +182,15 @@ public class OAuth2LoginController {
         return ResponseEntity.created(URI.create("/api/v1/members/" + newMember.getId())).body(response);
     }
 
-    private ResponseEntity<Oauth2SignUpResponse> createLoginResponse(Oauth2SignUpRequest signupForm,
-                                                                                       HttpSession session,
-                                                                                       Member member) {
-        String token = generateToken(member, signupForm.getProvider(), signupForm.getEmail(),
-                signupForm.getName());
+    private ResponseEntity<Oauth2SignUpResponse> createLoginResponse(HttpSession session, Member member) {
+        String email = (String) session.getAttribute("email");
+        String name = (String) session.getAttribute("name");
+        String provider = (String) session.getAttribute("provider");
+
+        String token = generateToken(member, provider, email, name);
         session.setAttribute("token", token);
 
-        Oauth2SignUpResponse response = Oauth2SignUpResponse.fromMember(member, signupForm.getEmail(),
-                signupForm.getName(), member.getRole().name(), signupForm.getProvider(), token);
+        Oauth2SignUpResponse response = Oauth2SignUpResponse.fromMember(member, email, name, member.getRole().name(), provider, token);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/patientpal/backend/member/service/MemberService.java
+++ b/src/main/java/com/patientpal/backend/member/service/MemberService.java
@@ -16,6 +16,7 @@ import com.patientpal.backend.patient.domain.Patient;
 import com.patientpal.backend.patient.repository.PatientRepository;
 import com.patientpal.backend.security.oauth.dto.Oauth2SignUpRequest;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -83,7 +84,6 @@ public class MemberService {
             if (request.getRole() == Role.CAREGIVER) {
                 Caregiver caregiver = Caregiver.builder()
                         .username(username)
-                        .password(passwordEncoder.encode(request.getPassword()))
                         .role(request.getRole())
                         .provider(Provider.valueOf(request.getProvider().toUpperCase()))
                         .build();
@@ -91,7 +91,6 @@ public class MemberService {
             } else if (request.getRole() == Role.USER) {
                 Patient patient = Patient.builder()
                         .username(username)
-                        .password(passwordEncoder.encode(request.getPassword()))
                         .role(request.getRole())
                         .provider(Provider.valueOf(request.getProvider().toUpperCase()))
                         .build();
@@ -99,7 +98,6 @@ public class MemberService {
             } else if (request.getRole() == Role.ADMIN) {
                 Member member = Member.builder()
                         .username(request.getUsername())
-                        .password(request.getPassword())
                         .role(Role.ADMIN)
                         .provider(Provider.valueOf(request.getProvider().toUpperCase()))
                         .build();
@@ -144,6 +142,12 @@ public class MemberService {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_EXIST));
     }
+
+    @Transactional(readOnly = true)
+    public Optional<Member> findOptionalByUsername(String username) {
+        return memberRepository.findByUsername(username);
+    }
+
 
     private void validateUsername(String username) {
         Pattern BASE_NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9]*$");

--- a/src/main/java/com/patientpal/backend/security/oauth/dto/Oauth2SignUpRequest.java
+++ b/src/main/java/com/patientpal/backend/security/oauth/dto/Oauth2SignUpRequest.java
@@ -4,9 +4,7 @@ import com.patientpal.backend.member.domain.Role;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 
 @Getter
@@ -19,9 +17,6 @@ public class Oauth2SignUpRequest {
     @NotBlank
     private String name;
 
-    @NotBlank
-    private String password;
-
     @NotNull
     private Role role;
 
@@ -32,13 +27,12 @@ public class Oauth2SignUpRequest {
     private String username;
 
     @Builder(toBuilder = true)
-    public Oauth2SignUpRequest(String email, String name, String password, Role role, String provider, String username) {
+    public Oauth2SignUpRequest(String email, String name, String provider, String username) {
         this.email = email;
         this.name = name;
-        this.password = password;
-        this.role = role;
         this.provider = provider;
         this.username = username;
+        this.role = Role.USER;
     }
 
 }

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -7,21 +7,21 @@ spring:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             scope: profile, email
-            redirect-uri: "{baseUrl}/login/oauth2/code/google"
+            redirect-uri: "http://localhost:8080/login/oauth2/code/google"
             authorization-grant-type: authorization_code
             client-name: Google
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
             scope: profile_nickname, account_email
-            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
             authorization-grant-type: authorization_code
             client-name: Kakao
           naver:
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
             scope: name, email
-            redirect-uri: "{baseUrl}/login/oauth2/code/naver"
+            redirect-uri: "http://localhost:8080/login/oauth2/code/naver"
             authorization-grant-type: authorization_code
             client-name: Naver
         provider:


### PR DESCRIPTION
<!-- 적절히 쪼개서 PR을 작성해주세요. 리뷰어가 한 번에 너무 많은 코드를 검토하면 읽기 어렵고 코드의 결함을 찾기 힘들어질 수 있어요! 😊 -->
## ✨ 작업 내용
- 각 provider 로그인 리다이렉트 제대로 됨
- 로그인 하면 code 및 state를 보내면 엑세스 토큰 발행
- 엑세스 토큰으로 요청하면 소셜 데이터 요청됨

<!-- PR을 만들게 된 맥락(이를 수행하는 이유나 관련 링크 등)을 리뷰어가 알아야 한다면 함께 작성해주세요. 리뷰어가 히스토리를 완전히 알고 있다고 가정하지 않는 것이 좋아요. 😉 -->
<!-- 기술적인 접근법에 대한 토론, 디자인에 대한 비평 등 원하는 피드백의 방향과 내용을 명확히 알려주세요! -->
## 💬 리뷰어에게 남길 멘트
- 

<!-- 이 PR과 관련된 이슈 번호를 명시해주세요. 🔢 -->
<!-- 예를 들어, #123 형식으로 작성해주시고, 닫으려는 이슈가 있다면 "Fixes #123" 또는 "Closes #123" 형식으로 작성해주시면 PR이 머지될 때 해당 이슈가 자동으로 닫힙니다. -->
## 🔗 관련 이슈
- 

<!-- 관련된 문서나 참고한 자료 링크를 추가해주세요! 🌐 -->
## 📚 레퍼런스
- 
